### PR TITLE
OverflowingAdd の実装を修正しオーバーロードを追加する

### DIFF
--- a/.generator/templates/OverflowingExtension.cs
+++ b/.generator/templates/OverflowingExtension.cs
@@ -39,16 +39,16 @@ namespace AgatePris.Intar.Extensions {
     {%- endfor %}
 {%- endfor %}
 
+{%- for t in ['int', 'uint', 'long', 'ulong'] %}
+        {{ inl }} public static bool OverflowingAdd(this {{ t }} x, {{ t }} y, out {{ t }} result) => Overflowing.OverflowingAdd(x, y, out result);
+        {{ inl }} public static {{ t }}? CheckedAdd(this {{ t }} x, {{ t }} y) => Overflowing.CheckedAdd(x, y);
+        {{ inl }} public static {{ t }} SaturatingAdd(this {{ t }} x, {{ t }} y) => Overflowing.SaturatingAdd(x, y);
+{%- endfor %}
+
 {%- for t in ["int", "uint"] %}
-    {%- for m in ["OverflowingAdd", "OverflowingMul"] %}
-        {{ inl }} public static bool {{ m }}(this {{ t }} x, {{ t }} y, out {{ t }} result) => Overflowing.{{ m }}(x, y, out result);
-    {%- endfor %}
-    {%- for m in ["CheckedAdd", "CheckedMul"] %}
-        {{ inl }} public static {{ t }}? {{ m }}(this {{ t }} x, {{ t }} y) => Overflowing.{{ m }}(x, y);
-    {%- endfor %}
-    {%- for m in ["SaturatingAdd", "SaturatingMul"] %}
-        {{ inl }} public static {{ t }} {{ m }}(this {{ t }} x, {{ t }} y) => Overflowing.{{ m }}(x, y);
-    {%- endfor %}
+        {{ inl }} public static bool OverflowingMul(this {{ t }} x, {{ t }} y, out {{ t }} result) => Overflowing.OverflowingMul(x, y, out result);
+        {{ inl }} public static {{ t }}? CheckedMul(this {{ t }} x, {{ t }} y) => Overflowing.CheckedMul(x, y);
+        {{ inl }} public static {{ t }} SaturatingMul(this {{ t }} x, {{ t }} y) => Overflowing.SaturatingMul(x, y);
 {%- endfor %}
     }
 }

--- a/AgatePris.Intar.Tests/OverflowingTest.cs
+++ b/AgatePris.Intar.Tests/OverflowingTest.cs
@@ -104,5 +104,221 @@ namespace AgatePris.Intar.Tests {
             Utility.AssertAreEqual(Overflowing.AbsDiff(u32_1, u32_100), 99);
             Utility.AssertAreEqual(Overflowing.AbsDiff(u64_1, u64_100), 99);
         }
+
+        [Test]
+        public static void TestOverflowingAddInt() {
+            var o01 = Overflowing.OverflowingAdd(int.MinValue, int.MinValue, out var _);
+            var o02 = Overflowing.OverflowingAdd(int.MinValue, int.MaxValue, out var _);
+            var o03 = Overflowing.OverflowingAdd(int.MaxValue, int.MinValue, out var _);
+            var o04 = Overflowing.OverflowingAdd(int.MaxValue, int.MaxValue, out var _);
+            var o05 = Overflowing.OverflowingAdd(int.MinValue, -1, out var _);
+            var o06 = Overflowing.OverflowingAdd(int.MaxValue, -1, out var r06);
+            var o07 = Overflowing.OverflowingAdd(int.MinValue, 0, out var r07);
+            var o08 = Overflowing.OverflowingAdd(int.MaxValue, 0, out var r08);
+            var o09 = Overflowing.OverflowingAdd(int.MinValue, 1, out var r09);
+            var o10 = Overflowing.OverflowingAdd(int.MaxValue, 1, out var _);
+            var o11 = Overflowing.OverflowingAdd(-1, int.MinValue, out var _);
+            var o12 = Overflowing.OverflowingAdd(-1, int.MaxValue, out var r12);
+            var o13 = Overflowing.OverflowingAdd(0, int.MinValue, out var r13);
+            var o14 = Overflowing.OverflowingAdd(0, int.MaxValue, out var r14);
+            var o15 = Overflowing.OverflowingAdd(1, int.MinValue, out var r15);
+            var o16 = Overflowing.OverflowingAdd(1, int.MaxValue, out var _);
+            var o17 = Overflowing.OverflowingAdd(-1, -1, out var r17);
+            var o18 = Overflowing.OverflowingAdd(-1, 0, out var r18);
+            var o19 = Overflowing.OverflowingAdd(-1, 1, out var r19);
+            var o20 = Overflowing.OverflowingAdd(0, -1, out var r20);
+            var o21 = Overflowing.OverflowingAdd(0, 0, out var r21);
+            var o22 = Overflowing.OverflowingAdd(0, 1, out var r22);
+            var o23 = Overflowing.OverflowingAdd(1, -1, out var r23);
+            var o24 = Overflowing.OverflowingAdd(1, 0, out var r24);
+            var o25 = Overflowing.OverflowingAdd(1, 1, out var r25);
+            Assert.IsTrue(o01);
+            Assert.IsFalse(o02);
+            Assert.IsFalse(o03);
+            Assert.IsTrue(o04);
+            Assert.IsTrue(o05);
+            Assert.IsFalse(o06);
+            Assert.IsFalse(o07);
+            Assert.IsFalse(o08);
+            Assert.IsFalse(o09);
+            Assert.IsTrue(o10);
+            Assert.IsTrue(o11);
+            Assert.IsFalse(o12);
+            Assert.IsFalse(o13);
+            Assert.IsFalse(o14);
+            Assert.IsFalse(o15);
+            Assert.IsTrue(o16);
+            Assert.IsFalse(o17);
+            Assert.IsFalse(o18);
+            Assert.IsFalse(o19);
+            Assert.IsFalse(o20);
+            Assert.IsFalse(o21);
+            Assert.IsFalse(o22);
+            Assert.IsFalse(o23);
+            Assert.IsFalse(o24);
+            Assert.IsFalse(o25);
+            Assert.AreEqual(int.MaxValue - 1, r06);
+            Assert.AreEqual(int.MinValue, r07);
+            Assert.AreEqual(int.MaxValue, r08);
+            Assert.AreEqual(int.MinValue + 1, r09);
+            Assert.AreEqual(int.MaxValue - 1, r12);
+            Assert.AreEqual(int.MinValue, r13);
+            Assert.AreEqual(int.MaxValue, r14);
+            Assert.AreEqual(int.MinValue + 1, r15);
+            Assert.AreEqual(-2, r17);
+            Assert.AreEqual(-1, r18);
+            Assert.AreEqual(0, r19);
+            Assert.AreEqual(-1, r20);
+            Assert.AreEqual(0, r21);
+            Assert.AreEqual(1, r22);
+            Assert.AreEqual(0, r23);
+            Assert.AreEqual(1, r24);
+            Assert.AreEqual(2, r25);
+        }
+
+        [Test]
+        public static void TestOverflowingAddLong() {
+            var o01 = Overflowing.OverflowingAdd(long.MinValue, long.MinValue, out var _);
+            var o02 = Overflowing.OverflowingAdd(long.MinValue, long.MaxValue, out var _);
+            var o03 = Overflowing.OverflowingAdd(long.MaxValue, long.MinValue, out var _);
+            var o04 = Overflowing.OverflowingAdd(long.MaxValue, long.MaxValue, out var _);
+            var o05 = Overflowing.OverflowingAdd(long.MinValue, -1, out var _);
+            var o06 = Overflowing.OverflowingAdd(long.MaxValue, -1, out var r06);
+            var o07 = Overflowing.OverflowingAdd(long.MinValue, 0, out var r07);
+            var o08 = Overflowing.OverflowingAdd(long.MaxValue, 0, out var r08);
+            var o09 = Overflowing.OverflowingAdd(long.MinValue, 1, out var r09);
+            var o10 = Overflowing.OverflowingAdd(long.MaxValue, 1, out var _);
+            var o11 = Overflowing.OverflowingAdd(-1, long.MinValue, out var _);
+            var o12 = Overflowing.OverflowingAdd(-1, long.MaxValue, out var r12);
+            var o13 = Overflowing.OverflowingAdd(0, long.MinValue, out var r13);
+            var o14 = Overflowing.OverflowingAdd(0, long.MaxValue, out var r14);
+            var o15 = Overflowing.OverflowingAdd(1, long.MinValue, out var r15);
+            var o16 = Overflowing.OverflowingAdd(1, long.MaxValue, out var _);
+            var o17 = Overflowing.OverflowingAdd(-1L, -1, out var r17);
+            var o18 = Overflowing.OverflowingAdd(-1L, 0, out var r18);
+            var o19 = Overflowing.OverflowingAdd(-1L, 1, out var r19);
+            var o20 = Overflowing.OverflowingAdd(0L, -1, out var r20);
+            var o21 = Overflowing.OverflowingAdd(0L, 0, out var r21);
+            var o22 = Overflowing.OverflowingAdd(0L, 1, out var r22);
+            var o23 = Overflowing.OverflowingAdd(1L, -1, out var r23);
+            var o24 = Overflowing.OverflowingAdd(1L, 0, out var r24);
+            var o25 = Overflowing.OverflowingAdd(1L, 1, out var r25);
+            Assert.IsTrue(o01);
+            Assert.IsFalse(o02);
+            Assert.IsFalse(o03);
+            Assert.IsTrue(o04);
+            Assert.IsTrue(o05);
+            Assert.IsFalse(o06);
+            Assert.IsFalse(o07);
+            Assert.IsFalse(o08);
+            Assert.IsFalse(o09);
+            Assert.IsTrue(o10);
+            Assert.IsTrue(o11);
+            Assert.IsFalse(o12);
+            Assert.IsFalse(o13);
+            Assert.IsFalse(o14);
+            Assert.IsFalse(o15);
+            Assert.IsTrue(o16);
+            Assert.IsFalse(o17);
+            Assert.IsFalse(o18);
+            Assert.IsFalse(o19);
+            Assert.IsFalse(o20);
+            Assert.IsFalse(o21);
+            Assert.IsFalse(o22);
+            Assert.IsFalse(o23);
+            Assert.IsFalse(o24);
+            Assert.IsFalse(o25);
+            Assert.AreEqual(long.MaxValue - 1, r06);
+            Assert.AreEqual(long.MinValue, r07);
+            Assert.AreEqual(long.MaxValue, r08);
+            Assert.AreEqual(long.MinValue + 1, r09);
+            Assert.AreEqual(long.MaxValue - 1, r12);
+            Assert.AreEqual(long.MinValue, r13);
+            Assert.AreEqual(long.MaxValue, r14);
+            Assert.AreEqual(long.MinValue + 1, r15);
+            Assert.AreEqual(-2, r17);
+            Assert.AreEqual(-1, r18);
+            Assert.AreEqual(0, r19);
+            Assert.AreEqual(-1, r20);
+            Assert.AreEqual(0, r21);
+            Assert.AreEqual(1, r22);
+            Assert.AreEqual(0, r23);
+            Assert.AreEqual(1, r24);
+            Assert.AreEqual(2, r25);
+        }
+
+        [Test]
+        public static void TestOverflowingAddUInt() {
+            var o01 = Overflowing.OverflowingAdd(uint.MinValue, uint.MinValue, out var r01);
+            var o02 = Overflowing.OverflowingAdd(uint.MinValue, uint.MaxValue, out var r02);
+            var o03 = Overflowing.OverflowingAdd(uint.MaxValue, uint.MinValue, out var r03);
+            var o04 = Overflowing.OverflowingAdd(uint.MaxValue, uint.MaxValue, out var _);
+            var o09 = Overflowing.OverflowingAdd(uint.MinValue, 1, out var r09);
+            var o10 = Overflowing.OverflowingAdd(uint.MaxValue, 1, out var _);
+            var o15 = Overflowing.OverflowingAdd(1, uint.MinValue, out var r15);
+            var o16 = Overflowing.OverflowingAdd(1, uint.MaxValue, out var _);
+            var o25 = Overflowing.OverflowingAdd(1U, 1, out var r25);
+            Assert.IsFalse(o01);
+            Assert.IsFalse(o02);
+            Assert.IsFalse(o03);
+            Assert.IsTrue(o04);
+            Assert.IsFalse(o09);
+            Assert.IsTrue(o10);
+            Assert.IsFalse(o15);
+            Assert.IsTrue(o16);
+            Assert.IsFalse(o25);
+            Assert.AreEqual(0, r01);
+            Assert.AreEqual(uint.MaxValue, r02);
+            Assert.AreEqual(uint.MaxValue, r03);
+            Assert.AreEqual(0, r01);
+            Assert.AreEqual(uint.MinValue + 1, r09);
+            Assert.AreEqual(uint.MinValue + 1, r15);
+            Assert.AreEqual(2, r25);
+        }
+
+        [Test]
+        public static void TestOverflowingAddULong() {
+            var o01 = Overflowing.OverflowingAdd(ulong.MinValue, ulong.MinValue, out var r01);
+            var o02 = Overflowing.OverflowingAdd(ulong.MinValue, ulong.MaxValue, out var r02);
+            var o03 = Overflowing.OverflowingAdd(ulong.MaxValue, ulong.MinValue, out var r03);
+            var o04 = Overflowing.OverflowingAdd(ulong.MaxValue, ulong.MaxValue, out var _);
+            var o09 = Overflowing.OverflowingAdd(ulong.MinValue, 1, out var r09);
+            var o10 = Overflowing.OverflowingAdd(ulong.MaxValue, 1, out var _);
+            var o15 = Overflowing.OverflowingAdd(1, ulong.MinValue, out var r15);
+            var o16 = Overflowing.OverflowingAdd(1, ulong.MaxValue, out var _);
+            var o25 = Overflowing.OverflowingAdd(1UL, 1, out var r25);
+            Assert.IsFalse(o01);
+            Assert.IsFalse(o02);
+            Assert.IsFalse(o03);
+            Assert.IsTrue(o04);
+            Assert.IsFalse(o09);
+            Assert.IsTrue(o10);
+            Assert.IsFalse(o15);
+            Assert.IsTrue(o16);
+            Assert.IsFalse(o25);
+            Assert.AreEqual(0, r01);
+            Assert.AreEqual(ulong.MaxValue, r02);
+            Assert.AreEqual(ulong.MaxValue, r03);
+            Assert.AreEqual(0, r01);
+            Assert.AreEqual(ulong.MinValue + 1, r09);
+            Assert.AreEqual(ulong.MinValue + 1, r15);
+            Assert.AreEqual(2, r25);
+        }
+
+        [Test]
+        public static void TestSaturatingAdd() {
+            Assert.AreEqual(ulong.MaxValue, Overflowing.SaturatingAdd(ulong.MaxValue - 1UL, 100UL));
+            Assert.AreEqual(uint.MaxValue, Overflowing.SaturatingAdd(uint.MaxValue - 1U, 100U));
+            Assert.AreEqual(101UL, Overflowing.SaturatingAdd(ulong.MinValue + 1UL, 100UL));
+            Assert.AreEqual(101U, Overflowing.SaturatingAdd(uint.MinValue + 1U, 100U));
+            Assert.AreEqual(long.MaxValue - 101, Overflowing.SaturatingAdd(long.MaxValue - 1, -100));
+            Assert.AreEqual(long.MinValue + 101, Overflowing.SaturatingAdd(long.MinValue + 1, 100));
+            Assert.AreEqual(int.MaxValue - 101, Overflowing.SaturatingAdd(int.MaxValue - 1, -100));
+            Assert.AreEqual(int.MinValue + 101, Overflowing.SaturatingAdd(int.MinValue + 1, 100));
+            Assert.AreEqual(long.MinValue, Overflowing.SaturatingAdd(long.MinValue + 1, -100));
+            Assert.AreEqual(long.MaxValue, Overflowing.SaturatingAdd(long.MaxValue - 1, 100));
+            Assert.AreEqual(int.MinValue, Overflowing.SaturatingAdd(int.MinValue + 1, -100));
+            Assert.AreEqual(int.MaxValue, Overflowing.SaturatingAdd(int.MaxValue - 1, 100));
+        }
     }
 }

--- a/AgatePris.Intar/Extensions/OverflowingExtension.gen.cs
+++ b/AgatePris.Intar/Extensions/OverflowingExtension.gen.cs
@@ -33,16 +33,22 @@ namespace AgatePris.Intar.Extensions {
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long WrappingAbs(this long x) => Overflowing.WrappingAbs(x);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong UnsignedAbs(this long x) => Overflowing.UnsignedAbs(x);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool OverflowingAdd(this int x, int y, out int result) => Overflowing.OverflowingAdd(x, y, out result);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool OverflowingMul(this int x, int y, out int result) => Overflowing.OverflowingMul(x, y, out result);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int? CheckedAdd(this int x, int y) => Overflowing.CheckedAdd(x, y);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int? CheckedMul(this int x, int y) => Overflowing.CheckedMul(x, y);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int SaturatingAdd(this int x, int y) => Overflowing.SaturatingAdd(x, y);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int SaturatingMul(this int x, int y) => Overflowing.SaturatingMul(x, y);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool OverflowingAdd(this uint x, uint y, out uint result) => Overflowing.OverflowingAdd(x, y, out result);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool OverflowingMul(this uint x, uint y, out uint result) => Overflowing.OverflowingMul(x, y, out result);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint? CheckedAdd(this uint x, uint y) => Overflowing.CheckedAdd(x, y);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint? CheckedMul(this uint x, uint y) => Overflowing.CheckedMul(x, y);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint SaturatingAdd(this uint x, uint y) => Overflowing.SaturatingAdd(x, y);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool OverflowingAdd(this long x, long y, out long result) => Overflowing.OverflowingAdd(x, y, out result);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long? CheckedAdd(this long x, long y) => Overflowing.CheckedAdd(x, y);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long SaturatingAdd(this long x, long y) => Overflowing.SaturatingAdd(x, y);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool OverflowingAdd(this ulong x, ulong y, out ulong result) => Overflowing.OverflowingAdd(x, y, out result);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong? CheckedAdd(this ulong x, ulong y) => Overflowing.CheckedAdd(x, y);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong SaturatingAdd(this ulong x, ulong y) => Overflowing.SaturatingAdd(x, y);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool OverflowingMul(this int x, int y, out int result) => Overflowing.OverflowingMul(x, y, out result);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int? CheckedMul(this int x, int y) => Overflowing.CheckedMul(x, y);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int SaturatingMul(this int x, int y) => Overflowing.SaturatingMul(x, y);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool OverflowingMul(this uint x, uint y, out uint result) => Overflowing.OverflowingMul(x, y, out result);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint? CheckedMul(this uint x, uint y) => Overflowing.CheckedMul(x, y);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint SaturatingMul(this uint x, uint y) => Overflowing.SaturatingMul(x, y);
     }
 }

--- a/AgatePris.Intar/Overflowing.gen.cs
+++ b/AgatePris.Intar/Overflowing.gen.cs
@@ -299,38 +299,234 @@ namespace AgatePris.Intar {
         //    return b ? (long?)null : result;
         //}
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool OverflowingAdd(int x, int y, out int result) {
-            var tmp = ((long)x) + y;
-            result = unchecked((int)tmp);
-            return tmp < int.MinValue || tmp > int.MaxValue;
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int? CheckedAdd(int x, int y) {
-            int? @null = null;
-            return OverflowingAdd(x, y, out var result) ? @null : result;
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int SaturatingAdd(int x, int y) {
-            return CheckedAdd(x, y) ?? ((x < 0) && (y < 0)
-                ? int.MinValue
-                : int.MaxValue);
-        }
-
+        /// <summary>
+        /// <para>Calculates <c>x + y</c></para>
+        /// </summary>
+        /// <returns>
+        /// Returns a boolean indicating whether an arithmetic overflow would occur.
+        /// </returns>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(false, Overflowing.OverflowingAdd(5U, 2U, out var result));
+        /// System.Assert.AreEqual(true, Overflowing.OverflowingAdd(uint.MaxValue, 1U, out result));
+        /// </code>
+        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool OverflowingAdd(uint x, uint y, out uint result) {
-            var tmp = ((ulong)x) + y;
-            result = unchecked((uint)tmp);
-            return tmp > uint.MaxValue;
+            // unchecked コンテキストでは、整数の演算結果はラップアラウンドする。
+            // 特に、符号なし整数のそれについては、C# 以外の言語 (C++ など) でも同様の振る舞いが期待できる。
+            // ラップアラウンドした場合、結果は両辺のどちらの値よりも必ず小さくなる。
+            result = unchecked(x + y);
+            return result < x;
         }
+
+        /// <summary>
+        /// Checked integer addition. Computes <c>x + y</c>,
+        /// returning <c>null</c> if overflow occured.
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(uint.MaxValue - 1U, Overflowing.CheckedAdd(uint.MaxValue - 2U, 1U));
+        /// System.Assert.AreEqual(null, Overflowing.CheckedAdd(uint.MaxValue - 2U, 3U));
+        /// </code>
+        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint? CheckedAdd(uint x, uint y) {
             uint? @null = null;
             return OverflowingAdd(x, y, out var result) ? @null : result;
         }
+
+        /// <summary>
+        /// Saturating integer addition. Computes <c>x + y</c>, saturating at the numeric bounds instead of overflowing.
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(101U, Overflowing.SaturatingAdd(100U, 1U));
+        /// System.Assert.AreEqual(uint.MaxValue, Overflowing.SaturatingAdd(uint.MaxValue, 127U));
+        /// </code>
+        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint SaturatingAdd(uint x, uint y) {
-            return CheckedAdd(x, y) ?? uint.MaxValue;
+        public static uint SaturatingAdd(uint x, uint y) => CheckedAdd(x, y) ?? uint.MaxValue;
+
+        /// <summary>
+        /// <para>Calculates <c>x + y</c></para>
+        /// </summary>
+        /// <returns>
+        /// Returns a boolean indicating whether an arithmetic overflow would occur.
+        /// </returns>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(false, Overflowing.OverflowingAdd(5U, 2U, out var result));
+        /// System.Assert.AreEqual(true, Overflowing.OverflowingAdd(uint.MaxValue, 1U, out result));
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool OverflowingAdd(ulong x, ulong y, out ulong result) {
+            // unchecked コンテキストでは、整数の演算結果はラップアラウンドする。
+            // 特に、符号なし整数のそれについては、C# 以外の言語 (C++ など) でも同様の振る舞いが期待できる。
+            // ラップアラウンドした場合、結果は両辺のどちらの値よりも必ず小さくなる。
+            result = unchecked(x + y);
+            return result < x;
+        }
+
+        /// <summary>
+        /// Checked integer addition. Computes <c>x + y</c>,
+        /// returning <c>null</c> if overflow occured.
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(uint.MaxValue - 1U, Overflowing.CheckedAdd(uint.MaxValue - 2U, 1U));
+        /// System.Assert.AreEqual(null, Overflowing.CheckedAdd(uint.MaxValue - 2U, 3U));
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong? CheckedAdd(ulong x, ulong y) {
+            ulong? @null = null;
+            return OverflowingAdd(x, y, out var result) ? @null : result;
+        }
+
+        /// <summary>
+        /// Saturating integer addition. Computes <c>x + y</c>, saturating at the numeric bounds instead of overflowing.
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(101U, Overflowing.SaturatingAdd(100U, 1U));
+        /// System.Assert.AreEqual(uint.MaxValue, Overflowing.SaturatingAdd(uint.MaxValue, 127U));
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong SaturatingAdd(ulong x, ulong y) => CheckedAdd(x, y) ?? ulong.MaxValue;
+
+        /// <summary>
+        /// <para>Calculates <c>x + y</c></para>
+        /// </summary>
+        /// <returns>
+        /// Returns a boolean indicating whether an arithmetic overflow would occur.
+        /// </returns>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(false, Overflowing.OverflowingAdd(5U, 2U, out var result));
+        /// System.Assert.AreEqual(true, Overflowing.OverflowingAdd(uint.MaxValue, 1U, out result));
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool OverflowingAdd(int x, int y, out int result) {
+            // 両辺の符号が異なる場合、オーバーフローは発生しない。
+            // オーバーフローが発生すると、
+            // 両辺の符号が正の場合、結果は両辺のどちらの値よりも必ず小さくなる。
+            // 両辺の符号が負の場合、結果は両辺のどちらの値よりも必ず大きくなる。
+            result = unchecked(x + y);
+            return
+                ((x < 0) && (y < 0) && (result > x)) ||
+                ((x > 0) && (y > 0) && (result < x));
+        }
+
+        /// <summary>
+        /// Checked integer addition. Computes <c>x + y</c>,
+        /// returning <c>null</c> if overflow occured.
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(uint.MaxValue - 1U, Overflowing.CheckedAdd(uint.MaxValue - 2U, 1U));
+        /// System.Assert.AreEqual(null, Overflowing.CheckedAdd(uint.MaxValue - 2U, 3U));
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int? CheckedAdd(int x, int y) {
+            int? @null = null;
+            return OverflowingAdd(x, y, out var result) ? @null : result;
+        }
+
+        /// <summary>
+        /// Saturating integer addition. Computes <c>x + y</c>, saturating at the numeric bounds instead of overflowing.
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(101U, Overflowing.SaturatingAdd(100U, 1U));
+        /// System.Assert.AreEqual(uint.MaxValue, Overflowing.SaturatingAdd(uint.MaxValue, 127U));
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int SaturatingAdd(int x, int y) {
+            // オーバーフローが起きた場合、両辺が負の場合は負方向のオーバーフロー、
+            // それ以外の場合は必ず正方向のオーバーフローとなる。
+            // 両辺の符号が異なる場合はオーバーフローが起きないが、
+            // それを検査するのは CheckedAdd の責務である。
+            return CheckedAdd(x, y) ?? ((x < 0) && (y < 0)
+                ? int.MinValue
+                : int.MaxValue);
+        }
+
+        /// <summary>
+        /// <para>Calculates <c>x + y</c></para>
+        /// </summary>
+        /// <returns>
+        /// Returns a boolean indicating whether an arithmetic overflow would occur.
+        /// </returns>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(false, Overflowing.OverflowingAdd(5U, 2U, out var result));
+        /// System.Assert.AreEqual(true, Overflowing.OverflowingAdd(uint.MaxValue, 1U, out result));
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool OverflowingAdd(long x, long y, out long result) {
+            // 両辺の符号が異なる場合、オーバーフローは発生しない。
+            // オーバーフローが発生すると、
+            // 両辺の符号が正の場合、結果は両辺のどちらの値よりも必ず小さくなる。
+            // 両辺の符号が負の場合、結果は両辺のどちらの値よりも必ず大きくなる。
+            result = unchecked(x + y);
+            return
+                ((x < 0) && (y < 0) && (result > x)) ||
+                ((x > 0) && (y > 0) && (result < x));
+        }
+
+        /// <summary>
+        /// Checked integer addition. Computes <c>x + y</c>,
+        /// returning <c>null</c> if overflow occured.
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(uint.MaxValue - 1U, Overflowing.CheckedAdd(uint.MaxValue - 2U, 1U));
+        /// System.Assert.AreEqual(null, Overflowing.CheckedAdd(uint.MaxValue - 2U, 3U));
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long? CheckedAdd(long x, long y) {
+            long? @null = null;
+            return OverflowingAdd(x, y, out var result) ? @null : result;
+        }
+
+        /// <summary>
+        /// Saturating integer addition. Computes <c>x + y</c>, saturating at the numeric bounds instead of overflowing.
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// System.Assert.AreEqual(101U, Overflowing.SaturatingAdd(100U, 1U));
+        /// System.Assert.AreEqual(uint.MaxValue, Overflowing.SaturatingAdd(uint.MaxValue, 127U));
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long SaturatingAdd(long x, long y) {
+            // オーバーフローが起きた場合、両辺が負の場合は負方向のオーバーフロー、
+            // それ以外の場合は必ず正方向のオーバーフローとなる。
+            // 両辺の符号が異なる場合はオーバーフローが起きないが、
+            // それを検査するのは CheckedAdd の責務である。
+            return CheckedAdd(x, y) ?? ((x < 0) && (y < 0)
+                ? long.MinValue
+                : long.MaxValue);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
`Overflowing.OverflowingAdd` の実装を修正する。

より大きな型にキャストする代わりに引数の符号および _unchecked_ コンテキストで計算した値と引数との比較によってオーバーフローが発生したか否かを判断するロジックに修正する。

上記に伴い `long` と `ulong` について、以下のオーバーロードを追加する。

- `Overflowing.OverflowingAdd`
- `Overflowing.CheckedAdd`
- `Overflowing.SaturatingAdd`
- `OverflowingExtension.OverflowingAdd`
- `OverflowingExtension.CheckedAdd`
- `OverflowingExtension.SaturatingAdd`
