### PR TITLE
固定小数点数型 整数型からの変換メソッドを刷新 

### DIFF
--- a/.generator/templates/Fixed.cs
+++ b/.generator/templates/Fixed.cs
@@ -60,23 +60,106 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static {{ self_type }} FromBits({{ self_bits_type }} bits) => new {{ self_type }}(bits);
 
+{#- 整数型からの変換 #}
+{%- for bits in [32, 64] %}
+    {%- for s in [true, false] %}
+        {%- set from = macros::inttype(bits=bits, signed=s) %}
+
+        {#- 符号の有無が同じで整数部の桁数が相手以上か、
+            自身が符号あり、相手が符号なしで
+            符号を除いた整数部の桁数が相手以上なら必ず変換可能 #}
+        {%- if signed == s and int_nbits >= bits
+            or signed and not s and int_nbits - 1 >= bits %}
+
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = {{ self_type }}.From(1);
+        /// System.Assert.AreEqual({{
+            macros::one(bits=int_nbits+frac_nbits, signed=signed)
+        }} &lt;&lt; {{ frac_nbits }}, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static {{ self_type }} From({{ from }} num) {
+            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
+            // 自身が符号あり、相手が符号なしの場合、
+            // 自身の符号部分を除いた整数部について同様である。
+            return FromBits(num * OneRepr);
+        }
+
+        {#- 変換に失敗する場合がある (表現の範囲外) 場合はこちら #}
+        {%- else %}
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = {{ self_type }}.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; {{ frac_nbits }}, a.Bits);
+        /// var a = {{ self_type }}.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; {{ frac_nbits }}, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static {{ self_type }} FromNum({{ self_bits_type }} num) => FromBits(num * OneRepr);
+        public static {{ self_type }}? CheckedFrom({{ from }} num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            {%- if signed %}
+                {%- if s %}
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+                {%- else %}
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > ({{ macros::inttype(bits=int_nbits+frac_nbits, signed=false) }})(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+                {%- endif %}
+            {%- else %}
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if (({{ macros::inttype(bits=bits, signed=false) }})num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+            {%- endif %}
+
+            return FromBits(({{ self_bits_type }})num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -89,12 +172,27 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = {{ self_type }}.StrictFromNum(1);
+        /// var a = {{ self_type }}.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; {{ frac_nbits }}, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static {{ self_type }} StrictFromNum({{ self_bits_type }} num) => FromBits(checked(num * OneRepr));
+        public static {{ self_type }} StrictFrom({{ from }} num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked(({{ self_bits_type }})num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        {%- endif %}
+    {%- endfor %}
+{%- endfor %}
 
         {%- set type_1 = ['float', '1.0f'] %}
         {%- set type_2 = ['double', '1.0'] %}

--- a/AgatePris.Intar.Tests/FixedTest.cs
+++ b/AgatePris.Intar.Tests/FixedTest.cs
@@ -6,15 +6,15 @@ namespace AgatePris.Intar.Tests {
     public class FixedTest {
         [Test]
         public static void Test() {
-            var a = I17F15.FromNum(1);
-            var b = I17F15.FromNum(2);
+            var a = I17F15.CheckedFrom(1).Value;
+            var b = I17F15.CheckedFrom(2).Value;
             a += b;
             Utility.AssertAreEqual(3, (int)a);
         }
 
         [Test]
         public static void TestStrictFromNum() {
-            _ = Assert.Throws<OverflowException>(() => I17F15.StrictFromNum(int.MaxValue));
+            _ = Assert.Throws<OverflowException>(() => I17F15.StrictFrom(int.MaxValue));
             _ = Assert.Throws<OverflowException>(() => I2F30.StrictFromNum(2.0f));
             _ = Assert.Throws<OverflowException>(() => I2F30.StrictFromNum(2.0));
             _ = Assert.Throws<OverflowException>(() => I2F30.StrictFromNum(2.0m));

--- a/AgatePris.Intar/I17F15.gen.cs
+++ b/AgatePris.Intar/I17F15.gen.cs
@@ -42,20 +42,38 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I17F15.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
+        /// var a = I17F15.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 FromNum(int num) => FromBits(num * OneRepr);
+        public static I17F15? CheckedFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((int)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -68,12 +86,220 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I17F15.StrictFromNum(1);
+        /// var a = I17F15.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 StrictFromNum(int num) => FromBits(checked(num * OneRepr));
+        public static I17F15 StrictFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((int)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I17F15.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I17F15? CheckedFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > (uint)(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+
+            return FromBits((int)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I17F15.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I17F15 StrictFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((int)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I17F15.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I17F15? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((int)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I17F15.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I17F15 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((int)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I17F15.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I17F15? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > (uint)(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+
+            return FromBits((int)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I17F15.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I17F15 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((int)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/I2F30.gen.cs
+++ b/AgatePris.Intar/I2F30.gen.cs
@@ -42,20 +42,38 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I2F30.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// var a = I2F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 FromNum(int num) => FromBits(num * OneRepr);
+        public static I2F30? CheckedFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((int)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -68,12 +86,220 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I2F30.StrictFromNum(1);
+        /// var a = I2F30.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 StrictFromNum(int num) => FromBits(checked(num * OneRepr));
+        public static I2F30 StrictFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((int)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F30? CheckedFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > (uint)(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+
+            return FromBits((int)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F30.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F30 StrictFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((int)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F30? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((int)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F30.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F30 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((int)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F30? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > (uint)(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+
+            return FromBits((int)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F30.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F30 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((int)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/I2F62.gen.cs
+++ b/AgatePris.Intar/I2F62.gen.cs
@@ -48,20 +48,38 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I2F62.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 62, a.Bits);
+        /// var a = I2F62.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 FromNum(long num) => FromBits(num * OneRepr);
+        public static I2F62? CheckedFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -74,12 +92,220 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I2F62.StrictFromNum(1);
+        /// var a = I2F62.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 62, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 StrictFromNum(long num) => FromBits(checked(num * OneRepr));
+        public static I2F62 StrictFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F62.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F62? CheckedFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > (ulong)(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F62.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F62 StrictFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F62.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F62? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F62.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F62 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F62.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F62? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > (ulong)(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I2F62.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I2F62 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/I33F31.gen.cs
+++ b/AgatePris.Intar/I33F31.gen.cs
@@ -48,20 +48,76 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I33F31.From(1);
+        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I33F31 From(int num) {
+            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
+            // 自身が符号あり、相手が符号なしの場合、
+            // 自身の符号部分を除いた整数部について同様である。
+            return FromBits(num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I33F31.From(1);
+        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I33F31 From(uint num) {
+            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
+            // 自身が符号あり、相手が符号なしの場合、
+            // 自身の符号部分を除いた整数部について同様である。
+            return FromBits(num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I33F31.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 31, a.Bits);
+        /// var a = I33F31.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 31, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 FromNum(long num) => FromBits(num * OneRepr);
+        public static I33F31? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -74,12 +130,89 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I33F31.StrictFromNum(1);
+        /// var a = I33F31.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 31, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 StrictFromNum(long num) => FromBits(checked(num * OneRepr));
+        public static I33F31 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I33F31.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 31, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I33F31? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > (ulong)(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I33F31.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 31, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I33F31 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/I34F30.gen.cs
+++ b/AgatePris.Intar/I34F30.gen.cs
@@ -48,20 +48,76 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I34F30.From(1);
+        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I34F30 From(int num) {
+            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
+            // 自身が符号あり、相手が符号なしの場合、
+            // 自身の符号部分を除いた整数部について同様である。
+            return FromBits(num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I34F30.From(1);
+        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I34F30 From(uint num) {
+            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
+            // 自身が符号あり、相手が符号なしの場合、
+            // 自身の符号部分を除いた整数部について同様である。
+            return FromBits(num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I34F30.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// var a = I34F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 FromNum(long num) => FromBits(num * OneRepr);
+        public static I34F30? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -74,12 +130,89 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I34F30.StrictFromNum(1);
+        /// var a = I34F30.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 StrictFromNum(long num) => FromBits(checked(num * OneRepr));
+        public static I34F30 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I34F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I34F30? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > (ulong)(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I34F30.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I34F30 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/I4F60.gen.cs
+++ b/AgatePris.Intar/I4F60.gen.cs
@@ -48,20 +48,38 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I4F60.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 60, a.Bits);
+        /// var a = I4F60.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 FromNum(long num) => FromBits(num * OneRepr);
+        public static I4F60? CheckedFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -74,12 +92,220 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = I4F60.StrictFromNum(1);
+        /// var a = I4F60.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 60, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 StrictFromNum(long num) => FromBits(checked(num * OneRepr));
+        public static I4F60 StrictFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I4F60.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I4F60? CheckedFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > (ulong)(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I4F60.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I4F60 StrictFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I4F60.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I4F60? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身と相手の両方が符号ありの場合、
+            // 比較演算の際に双方が大きい型に合わせて暗黙に変換される。
+            if (num > MaxValue.Bits / OneRepr ||
+                num < MinValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I4F60.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I4F60 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I4F60.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I4F60? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号あり、相手が符号なしであるから、
+            // 相手が最小値未満であることはありえない。
+            // よって、自身の最大値を符号なしの型に変換して比較する。
+            // この際、大きい方の型に暗黙に変換される。
+            if (num > (ulong)(MaxValue.Bits / OneRepr)) {
+                return null;
+            }
+
+            return FromBits((long)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = I4F60.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static I4F60 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((long)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/U17F15.gen.cs
+++ b/AgatePris.Intar/U17F15.gen.cs
@@ -42,20 +42,46 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U17F15.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
+        /// var a = U17F15.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 FromNum(uint num) => FromBits(num * OneRepr);
+        public static U17F15? CheckedFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((uint)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((uint)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -68,12 +94,242 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U17F15.StrictFromNum(1);
+        /// var a = U17F15.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 StrictFromNum(uint num) => FromBits(checked(num * OneRepr));
+        public static U17F15 StrictFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((uint)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U17F15.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U17F15? CheckedFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((uint)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((uint)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U17F15.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U17F15 StrictFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((uint)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U17F15.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U17F15? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((uint)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U17F15.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U17F15 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((uint)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U17F15.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U17F15? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((uint)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U17F15.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U17F15 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((uint)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/U2F30.gen.cs
+++ b/AgatePris.Intar/U2F30.gen.cs
@@ -42,20 +42,46 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U2F30.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// var a = U2F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 FromNum(uint num) => FromBits(num * OneRepr);
+        public static U2F30? CheckedFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((uint)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((uint)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -68,12 +94,242 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U2F30.StrictFromNum(1);
+        /// var a = U2F30.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 StrictFromNum(uint num) => FromBits(checked(num * OneRepr));
+        public static U2F30 StrictFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((uint)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F30? CheckedFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((uint)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((uint)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F30.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F30 StrictFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((uint)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F30? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((uint)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F30.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F30 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((uint)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F30? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((uint)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F30.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F30 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((uint)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/U2F62.gen.cs
+++ b/AgatePris.Intar/U2F62.gen.cs
@@ -48,20 +48,46 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U2F62.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 62, a.Bits);
+        /// var a = U2F62.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 FromNum(ulong num) => FromBits(num * OneRepr);
+        public static U2F62? CheckedFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((uint)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -74,12 +100,242 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U2F62.StrictFromNum(1);
+        /// var a = U2F62.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 62, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 StrictFromNum(ulong num) => FromBits(checked(num * OneRepr));
+        public static U2F62 StrictFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F62.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F62? CheckedFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((uint)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F62.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F62 StrictFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F62.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F62? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F62.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F62 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F62.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F62? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U2F62.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 62, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U2F62 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/U33F31.gen.cs
+++ b/AgatePris.Intar/U33F31.gen.cs
@@ -48,20 +48,46 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U33F31.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 31, a.Bits);
+        /// var a = U33F31.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 31, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 FromNum(ulong num) => FromBits(num * OneRepr);
+        public static U33F31? CheckedFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((uint)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -74,12 +100,188 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U33F31.StrictFromNum(1);
+        /// var a = U33F31.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 31, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 StrictFromNum(ulong num) => FromBits(checked(num * OneRepr));
+        public static U33F31 StrictFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U33F31.From(1);
+        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U33F31 From(uint num) {
+            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
+            // 自身が符号あり、相手が符号なしの場合、
+            // 自身の符号部分を除いた整数部について同様である。
+            return FromBits(num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U33F31.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 31, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U33F31? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U33F31.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 31, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U33F31 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U33F31.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 31, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U33F31? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U33F31.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 31, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U33F31 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/U34F30.gen.cs
+++ b/AgatePris.Intar/U34F30.gen.cs
@@ -48,20 +48,46 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U34F30.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// var a = U34F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 FromNum(ulong num) => FromBits(num * OneRepr);
+        public static U34F30? CheckedFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((uint)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -74,12 +100,188 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U34F30.StrictFromNum(1);
+        /// var a = U34F30.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 StrictFromNum(ulong num) => FromBits(checked(num * OneRepr));
+        public static U34F30 StrictFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U34F30.From(1);
+        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U34F30 From(uint num) {
+            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
+            // 自身が符号あり、相手が符号なしの場合、
+            // 自身の符号部分を除いた整数部について同様である。
+            return FromBits(num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U34F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U34F30? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U34F30.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U34F30 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U34F30.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U34F30? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U34F30.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U34F30 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>

--- a/AgatePris.Intar/U4F60.gen.cs
+++ b/AgatePris.Intar/U4F60.gen.cs
@@ -48,20 +48,46 @@ namespace AgatePris.Intar {
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
         /// <para>指定された数値から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドはオーバーフローを引き起こします。その場合の動作はビルド時の既定のオーバーフロー チェック コンテキストに従います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
         /// </div>
         /// </summary>
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U4F60.FromNum(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 60, a.Bits);
+        /// var a = U4F60.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a?.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 FromNum(ulong num) => FromBits(num * OneRepr);
+        public static U4F60? CheckedFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((uint)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>
@@ -74,12 +100,242 @@ namespace AgatePris.Intar {
         /// <example>
         /// Basic usage:
         /// <code>
-        /// var a = U4F60.StrictFromNum(1);
+        /// var a = U4F60.StrictFrom(1);
         /// System.Assert.AreEqual(1 &lt;&lt; 60, a.Bits);
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 StrictFromNum(ulong num) => FromBits(checked(num * OneRepr));
+        public static U4F60 StrictFrom(int num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U4F60.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U4F60? CheckedFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((uint)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U4F60.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U4F60 StrictFrom(uint num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U4F60.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U4F60? CheckedFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U4F60.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U4F60 StrictFrom(long num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U4F60.CheckedFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a?.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U4F60? CheckedFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            // 自身が符号なしで相手が 0 未満の場合は null
+            // この分岐は相手が符号なしなら最適化により消去される。
+            if (num < 0) {
+                return null;
+            }
+
+            // 相手が最大値より大きい場合は null
+            // この時点で 0 より大きいことが確定しているので、
+            // 相手を符号なしの型に変換してから比較する。
+            // 自身もまた符号なしであるから、
+            // 比較演算の際に必要なら暗黙の型変換が行われる。
+            if ((ulong)num > MaxValue.Bits / OneRepr) {
+                return null;
+            }
+
+            return FromBits((ulong)num * OneRepr);
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from specified num.</para>
+        /// <para>指定された数値から新しく固定小数点数を構築します。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <example>
+        /// Basic usage:
+        /// <code>
+        /// var a = U4F60.StrictFrom(1);
+        /// System.Assert.AreEqual(1 &lt;&lt; 60, a.Bits);
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static U4F60 StrictFrom(ulong num) {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079
+#pragma warning disable IDE0004
+
+            return FromBits(checked((ulong)num * OneRepr));
+
+#pragma warning restore IDE0004
+#pragma warning restore IDE0079
+
+        }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from specified num.</para>


### PR DESCRIPTION
内部表現型向けの `FromNum` を `StrictFrom` に置き換えた。また、結果が範囲外の場合に `null` を返すメソッド `CheckedFrom` を追加した。

これにより、コンパイル時のオプションに関わらず、変換に失敗した場合に例外を送出するメソッドと `null` を返すメソッドとの区別を明確にした。

また、必ず変換が成功する場合のメソッド `From` を追加し、その場合は同じ型を引数とする `CheckedFrom` と `StrictFrom` を定義しないことで、変換が必ず成功することを明確にした。

また、内部表現型以外の整数型からの変換メソッドを追加した。