### PR TITLE
固定小数点数から整数への変換の設計を変更

### DIFF
--- a/AgatePris.Intar.Tests/FixedTest.cs
+++ b/AgatePris.Intar.Tests/FixedTest.cs
@@ -9,7 +9,7 @@ namespace AgatePris.Intar.Tests {
             var a = I17F15.CheckedFrom(1).Value;
             var b = I17F15.CheckedFrom(2).Value;
             a += b;
-            Utility.AssertAreEqual(3, (int)a);
+            Utility.AssertAreEqual(3, a.ToInt32());
         }
 
         [Test]

--- a/AgatePris.Intar/I17F15.gen.cs
+++ b/AgatePris.Intar/I17F15.gen.cs
@@ -467,15 +467,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(I17F15 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(I17F15 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(I17F15 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(I17F15 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(I17F15 x) {
             const float k = 1.0f / OneRepr;
@@ -638,6 +629,133 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public Vector2I17F15 SaturatingMul(Vector2I17F15 other) => other.SaturatingMul(this);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public Vector3I17F15 SaturatingMul(Vector3I17F15 other) => other.SaturatingMul(this);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public Vector4I17F15 SaturatingMul(Vector4I17F15 other) => other.SaturatingMul(this);
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ToInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (int)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint StrictToUInt32() {
+            return checked((uint)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint? CheckedToUInt32() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((uint)tmp > uint.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (uint)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong StrictToUInt64() {
+            return checked((ulong)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong? CheckedToUInt64() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((uint)tmp > ulong.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (ulong)tmp;
+        }
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/I2F30.gen.cs
+++ b/AgatePris.Intar/I2F30.gen.cs
@@ -467,15 +467,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(I2F30 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(I2F30 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(I2F30 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(I2F30 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(I2F30 x) {
             const float k = 1.0f / OneRepr;
@@ -606,6 +597,133 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public Vector2I2F30 SaturatingMul(Vector2I2F30 other) => other.SaturatingMul(this);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public Vector3I2F30 SaturatingMul(Vector3I2F30 other) => other.SaturatingMul(this);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public Vector4I2F30 SaturatingMul(Vector4I2F30 other) => other.SaturatingMul(this);
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ToInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (int)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint StrictToUInt32() {
+            return checked((uint)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint? CheckedToUInt32() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((uint)tmp > uint.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (uint)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong StrictToUInt64() {
+            return checked((ulong)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong? CheckedToUInt64() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((uint)tmp > ulong.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (ulong)tmp;
+        }
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/I2F62.gen.cs
+++ b/AgatePris.Intar/I2F62.gen.cs
@@ -428,15 +428,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(I2F62 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(I2F62 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(I2F62 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(I2F62 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(I2F62 x) {
             const float k = 1.0f / OneRepr;
@@ -533,6 +524,133 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public I2F62 SaturatingAdd(I2F62 other) {
             return FromBits(Overflowing.SaturatingAdd(Bits, other.Bits));
+        }
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ToInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (int)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint StrictToUInt32() {
+            return checked((uint)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint? CheckedToUInt32() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((ulong)tmp > uint.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (uint)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong StrictToUInt64() {
+            return checked((ulong)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong? CheckedToUInt64() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((ulong)tmp > ulong.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (ulong)tmp;
         }
 
     }

--- a/AgatePris.Intar/I33F31.gen.cs
+++ b/AgatePris.Intar/I33F31.gen.cs
@@ -335,15 +335,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(I33F31 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(I33F31 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(I33F31 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(I33F31 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(I33F31 x) {
             const float k = 1.0f / OneRepr;
@@ -440,6 +431,151 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public I33F31 SaturatingAdd(I33F31 other) {
             return FromBits(Overflowing.SaturatingAdd(Bits, other.Bits));
+        }
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int StrictToInt32() {
+            return checked((int)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int? CheckedToInt32() {
+            var tmp = Bits / OneRepr;
+
+            // 自身と相手の符号が同じい場合、
+            // 暗黙に大きい方の型にキャストされる。
+            if (tmp < int.MinValue ||
+                tmp > int.MaxValue) {
+                return null;
+            }
+
+            return (int)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint StrictToUInt32() {
+            return checked((uint)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint? CheckedToUInt32() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((ulong)tmp > uint.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (uint)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong StrictToUInt64() {
+            return checked((ulong)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong? CheckedToUInt64() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((ulong)tmp > ulong.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (ulong)tmp;
         }
 
     }

--- a/AgatePris.Intar/I34F30.gen.cs
+++ b/AgatePris.Intar/I34F30.gen.cs
@@ -335,15 +335,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(I34F30 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(I34F30 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(I34F30 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(I34F30 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(I34F30 x) {
             const float k = 1.0f / OneRepr;
@@ -440,6 +431,151 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public I34F30 SaturatingAdd(I34F30 other) {
             return FromBits(Overflowing.SaturatingAdd(Bits, other.Bits));
+        }
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int StrictToInt32() {
+            return checked((int)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int? CheckedToInt32() {
+            var tmp = Bits / OneRepr;
+
+            // 自身と相手の符号が同じい場合、
+            // 暗黙に大きい方の型にキャストされる。
+            if (tmp < int.MinValue ||
+                tmp > int.MaxValue) {
+                return null;
+            }
+
+            return (int)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint StrictToUInt32() {
+            return checked((uint)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint? CheckedToUInt32() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((ulong)tmp > uint.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (uint)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong StrictToUInt64() {
+            return checked((ulong)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong? CheckedToUInt64() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((ulong)tmp > ulong.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (ulong)tmp;
         }
 
     }

--- a/AgatePris.Intar/I4F60.gen.cs
+++ b/AgatePris.Intar/I4F60.gen.cs
@@ -428,15 +428,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(I4F60 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(I4F60 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(I4F60 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(I4F60 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(I4F60 x) {
             const float k = 1.0f / OneRepr;
@@ -533,6 +524,133 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public I4F60 SaturatingAdd(I4F60 other) {
             return FromBits(Overflowing.SaturatingAdd(Bits, other.Bits));
+        }
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ToInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (int)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint StrictToUInt32() {
+            return checked((uint)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint? CheckedToUInt32() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((ulong)tmp > uint.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (uint)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong StrictToUInt64() {
+            return checked((ulong)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt64"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong? CheckedToUInt64() {
+            var tmp = Bits / OneRepr;
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+
+            // 自身が符号ありで、相手が符号なしの場合、
+            // 自身が 0 未満、または
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp < 0) {
+                return null;
+            } else if ((ulong)tmp > ulong.MaxValue) {
+                return null;
+            }
+
+#pragma warning restore CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+            return (ulong)tmp;
         }
 
     }

--- a/AgatePris.Intar/U17F15.gen.cs
+++ b/AgatePris.Intar/U17F15.gen.cs
@@ -493,15 +493,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(U17F15 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(U17F15 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(U17F15 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(U17F15 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(U17F15 x) {
             const float k = 1.0f / OneRepr;
@@ -629,6 +620,81 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public Vector4U17F15 SaturatingMul(Vector4U17F15 other) => other.SaturatingMul(this);
 
 #endif // AGATE_PRIS_INTAR_ENABLE_UNSIGNED_VECTOR
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ToInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (int)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint ToUInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (uint)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong ToUInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (ulong)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/U2F30.gen.cs
+++ b/AgatePris.Intar/U2F30.gen.cs
@@ -493,15 +493,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(U2F30 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(U2F30 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(U2F30 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(U2F30 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(U2F30 x) {
             const float k = 1.0f / OneRepr;
@@ -629,6 +620,81 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public Vector4U2F30 SaturatingMul(Vector4U2F30 other) => other.SaturatingMul(this);
 
 #endif // AGATE_PRIS_INTAR_ENABLE_UNSIGNED_VECTOR
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ToInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (int)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint ToUInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (uint)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong ToUInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (ulong)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/U2F62.gen.cs
+++ b/AgatePris.Intar/U2F62.gen.cs
@@ -455,15 +455,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(U2F62 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(U2F62 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(U2F62 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(U2F62 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(U2F62 x) {
             const float k = 1.0f / OneRepr;
@@ -553,6 +544,81 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public U2F62 SaturatingAdd(U2F62 other) {
             return FromBits(Overflowing.SaturatingAdd(Bits, other.Bits));
+        }
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ToInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (int)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint ToUInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (uint)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong ToUInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (ulong)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
         }
 
     }

--- a/AgatePris.Intar/U33F31.gen.cs
+++ b/AgatePris.Intar/U33F31.gen.cs
@@ -401,15 +401,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(U33F31 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(U33F31 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(U33F31 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(U33F31 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(U33F31 x) {
             const float k = 1.0f / OneRepr;
@@ -499,6 +490,116 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public U33F31 SaturatingAdd(U33F31 other) {
             return FromBits(Overflowing.SaturatingAdd(Bits, other.Bits));
+        }
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int StrictToInt32() {
+            return checked((int)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int? CheckedToInt32() {
+            var tmp = Bits / OneRepr;
+
+            // 自身が符号なしで、相手が符号ありの場合、
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp > int.MaxValue) {
+                return null;
+            }
+
+            return (int)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint StrictToUInt32() {
+            return checked((uint)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint? CheckedToUInt32() {
+            var tmp = Bits / OneRepr;
+
+            // 自身と相手の符号が同じい場合、
+            // 暗黙に大きい方の型にキャストされる。
+            if (tmp < uint.MinValue ||
+                tmp > uint.MaxValue) {
+                return null;
+            }
+
+            return (uint)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong ToUInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (ulong)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
         }
 
     }

--- a/AgatePris.Intar/U34F30.gen.cs
+++ b/AgatePris.Intar/U34F30.gen.cs
@@ -401,15 +401,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(U34F30 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(U34F30 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(U34F30 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(U34F30 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(U34F30 x) {
             const float k = 1.0f / OneRepr;
@@ -499,6 +490,116 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public U34F30 SaturatingAdd(U34F30 other) {
             return FromBits(Overflowing.SaturatingAdd(Bits, other.Bits));
+        }
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int StrictToInt32() {
+            return checked((int)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int? CheckedToInt32() {
+            var tmp = Bits / OneRepr;
+
+            // 自身が符号なしで、相手が符号ありの場合、
+            // 自身が相手の最大値よりも大きければ null
+            if (tmp > int.MaxValue) {
+                return null;
+            }
+
+            return (int)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="WARNING alert alert-info">
+        /// <h5>Warning</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="CheckedToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint StrictToUInt32() {
+            return checked((uint)(Bits / OneRepr));
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// <div class="NOTE alert alert-info">
+        /// <h5>Note</h5>
+        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
+        /// </div>
+        /// </summary>
+        /// <seealso cref="StrictToUInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint? CheckedToUInt32() {
+            var tmp = Bits / OneRepr;
+
+            // 自身と相手の符号が同じい場合、
+            // 暗黙に大きい方の型にキャストされる。
+            if (tmp < uint.MinValue ||
+                tmp > uint.MaxValue) {
+                return null;
+            }
+
+            return (uint)tmp;
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong ToUInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (ulong)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
         }
 
     }

--- a/AgatePris.Intar/U4F60.gen.cs
+++ b/AgatePris.Intar/U4F60.gen.cs
@@ -455,15 +455,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-#pragma warning disable IDE0004 // 不要なキャストの削除
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator int(U4F60 x) => (int)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator uint(U4F60 x) => (uint)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator long(U4F60 x) => (long)(x.Bits / OneRepr);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator ulong(U4F60 x) => (ulong)(x.Bits / OneRepr);
-
-#pragma warning restore IDE0004 // 不要なキャストの削除
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator float(U4F60 x) {
             const float k = 1.0f / OneRepr;
@@ -553,6 +544,81 @@ namespace AgatePris.Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public U4F60 SaturatingAdd(U4F60 other) {
             return FromBits(Overflowing.SaturatingAdd(Bits, other.Bits));
+        }
+
+        //
+        // Conversions
+        //
+
+        // 整数への変換で小数点以下の精度が失われるのは自明なので
+        // わざわざ明記することはしない。
+
+        /// <summary>
+        /// <para><see cref="int" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ToInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (int)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="uint" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint ToUInt32() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (uint)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="long" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ToInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (long)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
+        }
+
+        /// <summary>
+        /// <para><see cref="ulong" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong ToUInt64() {
+            // コード生成の簡単のため、冗長なキャストを許容する。
+
+#pragma warning disable IDE0079 // 不要な抑制を削除します
+#pragma warning disable IDE0004 // 不要なキャストの削除
+
+            return (ulong)(Bits / OneRepr);
+
+#pragma warning restore IDE0004 // 不要なキャストの削除
+#pragma warning restore IDE0079 // 不要な抑制を削除します
+
         }
 
     }


### PR DESCRIPTION
`operator int` や `operator long` などを削除し `ToInt32` `CheckedToInt32` `StrictToInt32` `ToInt64` などのメソッドに置き換え。