### PR TITLE
固定小数点数から浮動小数点数への変換について設計を改善

### DIFF
--- a/AgatePris.Intar.Tests/Numerics/VectorTest.cs
+++ b/AgatePris.Intar.Tests/Numerics/VectorTest.cs
@@ -5,10 +5,10 @@ namespace AgatePris.Intar.Tests.Numerics {
     public class VectorTest {
         static void Test(I17F15 x, I17F15 y, I17F15 z, I17F15 w) {
             var p = new System.Numerics.Vector4(
-                (float)x,
-                (float)y,
-                (float)z,
-                (float)w);
+                x.LossyToSingle(),
+                y.LossyToSingle(),
+                z.LossyToSingle(),
+                w.LossyToSingle());
             var q = new Vector4I17F15(x, y, z, w);
             {
                 var e = System.Numerics.Vector4.Normalize(p);
@@ -21,17 +21,17 @@ namespace AgatePris.Intar.Tests.Numerics {
                         float.IsNaN(e.W));
                 }
                 const double delta = 0.00004;
-                Utility.AssertAreEqual(e.X, (float)(a?.X ?? I17F15.Zero), delta);
-                Utility.AssertAreEqual(e.Y, (float)(a?.Y ?? I17F15.Zero), delta);
-                Utility.AssertAreEqual(e.Z, (float)(a?.Z ?? I17F15.Zero), delta);
-                Utility.AssertAreEqual(e.W, (float)(a?.W ?? I17F15.Zero), delta);
+                Utility.AssertAreEqual(e.X, (a?.X ?? I17F15.Zero).LossyToSingle(), delta);
+                Utility.AssertAreEqual(e.Y, (a?.Y ?? I17F15.Zero).LossyToSingle(), delta);
+                Utility.AssertAreEqual(e.Z, (a?.Z ?? I17F15.Zero).LossyToSingle(), delta);
+                Utility.AssertAreEqual(e.W, (a?.W ?? I17F15.Zero).LossyToSingle(), delta);
             }
         }
         static void Test(I17F15 x, I17F15 y, I17F15 z) {
             var p = new System.Numerics.Vector3(
-                (float)x,
-                (float)y,
-                (float)z);
+                x.LossyToSingle(),
+                y.LossyToSingle(),
+                z.LossyToSingle());
             var q = new Vector3I17F15(x, y, z);
             {
                 var e = System.Numerics.Vector3.Normalize(p);
@@ -43,25 +43,25 @@ namespace AgatePris.Intar.Tests.Numerics {
                         float.IsNaN(e.Z));
                 }
                 const double delta = 0.00004;
-                Utility.AssertAreEqual(e.X, (float)(a?.X ?? I17F15.Zero), delta);
-                Utility.AssertAreEqual(e.Y, (float)(a?.Y ?? I17F15.Zero), delta);
-                Utility.AssertAreEqual(e.Z, (float)(a?.Z ?? I17F15.Zero), delta);
+                Utility.AssertAreEqual(e.X, (a?.X ?? I17F15.Zero).LossyToSingle(), delta);
+                Utility.AssertAreEqual(e.Y, (a?.Y ?? I17F15.Zero).LossyToSingle(), delta);
+                Utility.AssertAreEqual(e.Z, (a?.Z ?? I17F15.Zero).LossyToSingle(), delta);
             }
             {
                 var a = q.LengthSquared();
                 const double delta = 1024;
-                Utility.AssertAreEqual(p.LengthSquared(), (float)a, delta);
+                Utility.AssertAreEqual(p.LengthSquared(), a.LossyToSingle(), delta);
             }
             {
                 var a = q.Length();
                 const double delta = 0.008;
-                Utility.AssertAreEqual(p.Length(), (float)a, delta);
+                Utility.AssertAreEqual(p.Length(), a.LossyToSingle(), delta);
             }
         }
         static void Test(I17F15 x, I17F15 y) {
             var p = new System.Numerics.Vector2(
-                (float)x,
-                (float)y);
+                x.LossyToSingle(),
+                y.LossyToSingle());
             var q = new Vector2I17F15(x, y);
             {
                 var e = System.Numerics.Vector2.Normalize(p);
@@ -72,18 +72,18 @@ namespace AgatePris.Intar.Tests.Numerics {
                         float.IsNaN(e.Y));
                 }
                 const double delta = 0.00004;
-                Utility.AssertAreEqual(e.X, (float)(a?.X ?? I17F15.Zero), delta);
-                Utility.AssertAreEqual(e.Y, (float)(a?.Y ?? I17F15.Zero), delta);
+                Utility.AssertAreEqual(e.X, (a?.X ?? I17F15.Zero).LossyToSingle(), delta);
+                Utility.AssertAreEqual(e.Y, (a?.Y ?? I17F15.Zero).LossyToSingle(), delta);
             }
             {
                 var a = q.LengthSquared();
                 const double delta = 1024;
-                Utility.AssertAreEqual(p.LengthSquared(), (float)a, delta);
+                Utility.AssertAreEqual(p.LengthSquared(), a.LossyToSingle(), delta);
             }
             {
                 var a = q.Length();
                 const double delta = 0.008;
-                Utility.AssertAreEqual(p.Length(), (float)a, delta);
+                Utility.AssertAreEqual(p.Length(), a.LossyToSingle(), delta);
             }
         }
 

--- a/AgatePris.Intar/I17F15.gen.cs
+++ b/AgatePris.Intar/I17F15.gen.cs
@@ -467,24 +467,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(I17F15 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(I17F15 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(I17F15 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(I17F15 x) => I2F30.FromBits(x.Bits * (1 << 15));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static implicit operator I34F30(I17F15 x) => I34F30.FromBits(x.Bits * (1L << 15));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static implicit operator I33F31(I17F15 x) => I33F31.FromBits(x.Bits * (1L << 16));
@@ -506,7 +488,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => ToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<I17F15>
         // ---------------------------------------
@@ -519,7 +501,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return ToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -756,6 +738,15 @@ namespace AgatePris.Intar {
 
             return (ulong)tmp;
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double ToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/I2F30.gen.cs
+++ b/AgatePris.Intar/I2F30.gen.cs
@@ -467,24 +467,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(I2F30 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(I2F30 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(I2F30 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(I2F30 x) => I17F15.FromBits(x.Bits / (1 << 15));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static implicit operator I34F30(I2F30 x) => I34F30.FromBits(x.Bits);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static implicit operator I33F31(I2F30 x) => I33F31.FromBits(x.Bits * (1L << 1));
@@ -506,7 +488,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => ToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<I2F30>
         // ---------------------------------------
@@ -519,7 +501,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return ToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -724,6 +706,15 @@ namespace AgatePris.Intar {
 
             return (ulong)tmp;
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double ToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/I2F62.gen.cs
+++ b/AgatePris.Intar/I2F62.gen.cs
@@ -428,24 +428,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(I2F62 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(I2F62 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(I2F62 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(I2F62 x) => I17F15.FromBits((int)(x.Bits / (1L << 47)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(I2F62 x) => I2F30.FromBits((int)(x.Bits / (1L << 32)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I34F30(I2F62 x) => I34F30.FromBits(x.Bits / (1L << 32));
@@ -467,7 +449,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<I2F62>
         // ---------------------------------------
@@ -480,7 +462,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return LossyToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -652,6 +634,15 @@ namespace AgatePris.Intar {
 
             return (ulong)tmp;
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LossyToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/I33F31.gen.cs
+++ b/AgatePris.Intar/I33F31.gen.cs
@@ -335,24 +335,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(I33F31 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(I33F31 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(I33F31 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(I33F31 x) => I17F15.FromBits((int)(x.Bits / (1L << 16)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(I33F31 x) => I2F30.FromBits((int)(x.Bits / (1L << 1)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I34F30(I33F31 x) => I34F30.FromBits(x.Bits / (1L << 1));
@@ -374,7 +356,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<I33F31>
         // ---------------------------------------
@@ -387,7 +369,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return LossyToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -577,6 +559,15 @@ namespace AgatePris.Intar {
 
             return (ulong)tmp;
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LossyToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/I34F30.gen.cs
+++ b/AgatePris.Intar/I34F30.gen.cs
@@ -335,24 +335,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(I34F30 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(I34F30 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(I34F30 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(I34F30 x) => I17F15.FromBits((int)(x.Bits / (1L << 15)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(I34F30 x) => I2F30.FromBits((int)x.Bits);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I33F31(I34F30 x) => I33F31.FromBits(x.Bits * (1L << 1));
@@ -374,7 +356,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<I34F30>
         // ---------------------------------------
@@ -387,7 +369,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return LossyToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -577,6 +559,15 @@ namespace AgatePris.Intar {
 
             return (ulong)tmp;
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LossyToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/I4F60.gen.cs
+++ b/AgatePris.Intar/I4F60.gen.cs
@@ -428,24 +428,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(I4F60 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(I4F60 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(I4F60 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(I4F60 x) => I17F15.FromBits((int)(x.Bits / (1L << 45)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(I4F60 x) => I2F30.FromBits((int)(x.Bits / (1L << 30)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I34F30(I4F60 x) => I34F30.FromBits(x.Bits / (1L << 30));
@@ -467,7 +449,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<I4F60>
         // ---------------------------------------
@@ -480,7 +462,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return LossyToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -652,6 +634,15 @@ namespace AgatePris.Intar {
 
             return (ulong)tmp;
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LossyToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/U17F15.gen.cs
+++ b/AgatePris.Intar/U17F15.gen.cs
@@ -465,24 +465,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(U17F15 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(U17F15 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(U17F15 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(U17F15 x) => I17F15.FromBits((int)x.Bits);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(U17F15 x) => I2F30.FromBits((int)x.Bits * (1 << 15));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static implicit operator I34F30(U17F15 x) => I34F30.FromBits(x.Bits * (1L << 15));
@@ -504,7 +486,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => ToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<U17F15>
         // ---------------------------------------
@@ -517,7 +499,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return ToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -667,6 +649,15 @@ namespace AgatePris.Intar {
 #pragma warning restore IDE0079 // 不要な抑制を削除します
 
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double ToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/U2F30.gen.cs
+++ b/AgatePris.Intar/U2F30.gen.cs
@@ -465,24 +465,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(U2F30 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(U2F30 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(U2F30 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(U2F30 x) => I17F15.FromBits((int)(x.Bits / (1U << 15)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(U2F30 x) => I2F30.FromBits((int)x.Bits);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static implicit operator I34F30(U2F30 x) => I34F30.FromBits(x.Bits);
@@ -504,7 +486,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => ToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<U2F30>
         // ---------------------------------------
@@ -517,7 +499,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return ToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -667,6 +649,15 @@ namespace AgatePris.Intar {
 #pragma warning restore IDE0079 // 不要な抑制を削除します
 
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double ToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/U2F62.gen.cs
+++ b/AgatePris.Intar/U2F62.gen.cs
@@ -427,24 +427,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(U2F62 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(U2F62 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(U2F62 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(U2F62 x) => I17F15.FromBits((int)(x.Bits / (1UL << 47)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(U2F62 x) => I2F30.FromBits((int)(x.Bits / (1UL << 32)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I34F30(U2F62 x) => I34F30.FromBits((long)(x.Bits / (1UL << 32)));
@@ -466,7 +448,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<U2F62>
         // ---------------------------------------
@@ -479,7 +461,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return LossyToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -592,6 +574,15 @@ namespace AgatePris.Intar {
 #pragma warning restore IDE0079 // 不要な抑制を削除します
 
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LossyToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/U33F31.gen.cs
+++ b/AgatePris.Intar/U33F31.gen.cs
@@ -381,24 +381,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(U33F31 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(U33F31 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(U33F31 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(U33F31 x) => I17F15.FromBits((int)(x.Bits / (1UL << 16)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(U33F31 x) => I2F30.FromBits((int)(x.Bits / (1UL << 1)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I34F30(U33F31 x) => I34F30.FromBits((long)(x.Bits / (1UL << 1)));
@@ -420,7 +402,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<U33F31>
         // ---------------------------------------
@@ -433,7 +415,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return LossyToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -581,6 +563,15 @@ namespace AgatePris.Intar {
 #pragma warning restore IDE0079 // 不要な抑制を削除します
 
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LossyToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/U34F30.gen.cs
+++ b/AgatePris.Intar/U34F30.gen.cs
@@ -381,24 +381,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(U34F30 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(U34F30 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(U34F30 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(U34F30 x) => I17F15.FromBits((int)(x.Bits / (1UL << 15)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(U34F30 x) => I2F30.FromBits((int)x.Bits);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I34F30(U34F30 x) => I34F30.FromBits((long)x.Bits);
@@ -420,7 +402,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<U34F30>
         // ---------------------------------------
@@ -433,7 +415,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return LossyToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -581,6 +563,15 @@ namespace AgatePris.Intar {
 #pragma warning restore IDE0079 // 不要な抑制を削除します
 
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LossyToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar

--- a/AgatePris.Intar/U4F60.gen.cs
+++ b/AgatePris.Intar/U4F60.gen.cs
@@ -427,24 +427,6 @@ namespace AgatePris.Intar {
         // Conversion operators
         // --------------------
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator float(U4F60 x) {
-            const float k = 1.0f / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator double(U4F60 x) {
-            const double k = 1.0 / OneRepr;
-            return k * x.Bits;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator decimal(U4F60 x) {
-            const decimal k = 1.0M / OneRepr;
-            return k * x.Bits;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I17F15(U4F60 x) => I17F15.FromBits((int)(x.Bits / (1UL << 45)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I2F30(U4F60 x) => I2F30.FromBits((int)(x.Bits / (1UL << 30)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static explicit operator I34F30(U4F60 x) => I34F30.FromBits((long)(x.Bits / (1UL << 30)));
@@ -466,7 +448,7 @@ namespace AgatePris.Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
+        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
 
         // IEquatable<U4F60>
         // ---------------------------------------
@@ -479,7 +461,7 @@ namespace AgatePris.Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ((double)this).ToString(format, formatProvider);
+            return LossyToDouble().ToString(format, formatProvider);
         }
 
         // Methods
@@ -592,6 +574,15 @@ namespace AgatePris.Intar {
 #pragma warning restore IDE0079 // 不要な抑制を削除します
 
         }
+
+        // 浮動小数点数への変換は必ず成功する。
+        // 除算は最適化によって乗算に置き換えられることを期待する。
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LossyToSingle() => (float)Bits / OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double LossyToDouble() => (double)Bits / OneRepr;
 
     }
 } // namespace AgatePris.Intar


### PR DESCRIPTION
`operator decimal` を削除した。また `LossyToSingle` `LossyToDouble` `ToDouble` を追加した。