### PR TITLE
OverflowingMul(uint, uint, out uint) 不具合修正

### DIFF
--- a/AgatePris.Intar/Overflowing.gen.cs
+++ b/AgatePris.Intar/Overflowing.gen.cs
@@ -548,7 +548,7 @@ namespace AgatePris.Intar {
         public static bool OverflowingMul(uint x, uint y, out uint result) {
             var l = ((ulong)x) * y;
             result = unchecked((uint)l);
-            return l > int.MaxValue;
+            return l > uint.MaxValue;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint? CheckedMul(uint x, uint y) {


### PR DESCRIPTION
オーバーフロー発生時に uint.MaxValue ではなく
int.MaxValue を返していた不具合を修正