### PR TITLE
固定小数点数ベクトル型 Dot 精度が失われないように仕様を変更

### DIFF
--- a/.generator/templates/Vector.cs
+++ b/.generator/templates/Vector.cs
@@ -276,28 +276,8 @@ namespace AgatePris.Intar {
 {%- if int_nbits+frac_nbits < 64 %}
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        {{ wide_bits }} DotInternal({{ self_type }} other) {
-            var x = (({{ wide_bits }})X.Bits) * other.X.Bits;
-            var y = (({{ wide_bits }})Y.Bits) * other.Y.Bits;{% if dim > 2 %}
-            var z = (({{ wide_bits }})Z.Bits) * other.Z.Bits;{% if dim > 3 %}
-            var w = (({{ wide_bits }})W.Bits) * other.W.Bits;{% endif %}{% endif %}
-
-            // オーバーフローを避けるため､ 事前に除算する｡
-            // 2 次元から 4 次元までのすべての次元で同じ結果を得るため､
-            // 精度を犠牲にしても 4 次元の計算に合わせて常に 4 で除算する｡
-            return
-                (x / 4) +
-                (y / 4){% if dim > 2 %} +
-                (z / 4){% if dim > 3 %} +
-                (w / 4){% endif %}{% endif %};
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public {{ component }} Dot({{ self_type }} other) {
-            const {{ wide_bits }} k = {{
-                macros::one(signed=signed, bits=2*(int_nbits+frac_nbits))
-            }} << {{ frac_nbits - 2 }};
-            return {{ component }}.FromBits(({{ bits }})(DotInternal(other) / k));
+        public {{ wide_component }} UncheckedDot({{ self_type }} other) {
+            return {{ wide_component }}.FromBits(Repr.UncheckedDot(other.Repr));
         }
 
     {%- if not signed or dim > 3 %}

--- a/AgatePris.Intar/Vector2I17F15.gen.cs
+++ b/AgatePris.Intar/Vector2I17F15.gen.cs
@@ -208,22 +208,8 @@ namespace AgatePris.Intar {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        long DotInternal(Vector2I17F15 other) {
-            var x = ((long)X.Bits) * other.X.Bits;
-            var y = ((long)Y.Bits) * other.Y.Bits;
-
-            // オーバーフローを避けるため､ 事前に除算する｡
-            // 2 次元から 4 次元までのすべての次元で同じ結果を得るため､
-            // 精度を犠牲にしても 4 次元の計算に合わせて常に 4 で除算する｡
-            return
-                (x / 4) +
-                (y / 4);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I17F15 Dot(Vector2I17F15 other) {
-            const long k = 1L << 13;
-            return I17F15.FromBits((int)(DotInternal(other) / k));
+        public I34F30 UncheckedDot(Vector2I17F15 other) {
+            return I34F30.FromBits(Repr.UncheckedDot(other.Repr));
         }
 
         /// <summary>

--- a/AgatePris.Intar/Vector2I2F30.gen.cs
+++ b/AgatePris.Intar/Vector2I2F30.gen.cs
@@ -208,22 +208,8 @@ namespace AgatePris.Intar {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        long DotInternal(Vector2I2F30 other) {
-            var x = ((long)X.Bits) * other.X.Bits;
-            var y = ((long)Y.Bits) * other.Y.Bits;
-
-            // オーバーフローを避けるため､ 事前に除算する｡
-            // 2 次元から 4 次元までのすべての次元で同じ結果を得るため､
-            // 精度を犠牲にしても 4 次元の計算に合わせて常に 4 で除算する｡
-            return
-                (x / 4) +
-                (y / 4);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F30 Dot(Vector2I2F30 other) {
-            const long k = 1L << 28;
-            return I2F30.FromBits((int)(DotInternal(other) / k));
+        public I4F60 UncheckedDot(Vector2I2F30 other) {
+            return I4F60.FromBits(Repr.UncheckedDot(other.Repr));
         }
 
         /// <summary>

--- a/AgatePris.Intar/Vector3I17F15.gen.cs
+++ b/AgatePris.Intar/Vector3I17F15.gen.cs
@@ -221,24 +221,8 @@ namespace AgatePris.Intar {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        long DotInternal(Vector3I17F15 other) {
-            var x = ((long)X.Bits) * other.X.Bits;
-            var y = ((long)Y.Bits) * other.Y.Bits;
-            var z = ((long)Z.Bits) * other.Z.Bits;
-
-            // オーバーフローを避けるため､ 事前に除算する｡
-            // 2 次元から 4 次元までのすべての次元で同じ結果を得るため､
-            // 精度を犠牲にしても 4 次元の計算に合わせて常に 4 で除算する｡
-            return
-                (x / 4) +
-                (y / 4) +
-                (z / 4);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I17F15 Dot(Vector3I17F15 other) {
-            const long k = 1L << 13;
-            return I17F15.FromBits((int)(DotInternal(other) / k));
+        public I34F30 UncheckedDot(Vector3I17F15 other) {
+            return I34F30.FromBits(Repr.UncheckedDot(other.Repr));
         }
 
         /// <summary>

--- a/AgatePris.Intar/Vector3I2F30.gen.cs
+++ b/AgatePris.Intar/Vector3I2F30.gen.cs
@@ -221,24 +221,8 @@ namespace AgatePris.Intar {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        long DotInternal(Vector3I2F30 other) {
-            var x = ((long)X.Bits) * other.X.Bits;
-            var y = ((long)Y.Bits) * other.Y.Bits;
-            var z = ((long)Z.Bits) * other.Z.Bits;
-
-            // オーバーフローを避けるため､ 事前に除算する｡
-            // 2 次元から 4 次元までのすべての次元で同じ結果を得るため､
-            // 精度を犠牲にしても 4 次元の計算に合わせて常に 4 で除算する｡
-            return
-                (x / 4) +
-                (y / 4) +
-                (z / 4);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F30 Dot(Vector3I2F30 other) {
-            const long k = 1L << 28;
-            return I2F30.FromBits((int)(DotInternal(other) / k));
+        public I4F60 UncheckedDot(Vector3I2F30 other) {
+            return I4F60.FromBits(Repr.UncheckedDot(other.Repr));
         }
 
         /// <summary>

--- a/AgatePris.Intar/Vector4I17F15.gen.cs
+++ b/AgatePris.Intar/Vector4I17F15.gen.cs
@@ -222,26 +222,8 @@ namespace AgatePris.Intar {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        long DotInternal(Vector4I17F15 other) {
-            var x = ((long)X.Bits) * other.X.Bits;
-            var y = ((long)Y.Bits) * other.Y.Bits;
-            var z = ((long)Z.Bits) * other.Z.Bits;
-            var w = ((long)W.Bits) * other.W.Bits;
-
-            // オーバーフローを避けるため､ 事前に除算する｡
-            // 2 次元から 4 次元までのすべての次元で同じ結果を得るため､
-            // 精度を犠牲にしても 4 次元の計算に合わせて常に 4 で除算する｡
-            return
-                (x / 4) +
-                (y / 4) +
-                (z / 4) +
-                (w / 4);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I17F15 Dot(Vector4I17F15 other) {
-            const long k = 1L << 13;
-            return I17F15.FromBits((int)(DotInternal(other) / k));
+        public I34F30 UncheckedDot(Vector4I17F15 other) {
+            return I34F30.FromBits(Repr.UncheckedDot(other.Repr));
         }
 
         // ベクトルの長さは符号つき、

--- a/AgatePris.Intar/Vector4I2F30.gen.cs
+++ b/AgatePris.Intar/Vector4I2F30.gen.cs
@@ -222,26 +222,8 @@ namespace AgatePris.Intar {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        long DotInternal(Vector4I2F30 other) {
-            var x = ((long)X.Bits) * other.X.Bits;
-            var y = ((long)Y.Bits) * other.Y.Bits;
-            var z = ((long)Z.Bits) * other.Z.Bits;
-            var w = ((long)W.Bits) * other.W.Bits;
-
-            // オーバーフローを避けるため､ 事前に除算する｡
-            // 2 次元から 4 次元までのすべての次元で同じ結果を得るため､
-            // 精度を犠牲にしても 4 次元の計算に合わせて常に 4 で除算する｡
-            return
-                (x / 4) +
-                (y / 4) +
-                (z / 4) +
-                (w / 4);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F30 Dot(Vector4I2F30 other) {
-            const long k = 1L << 28;
-            return I2F30.FromBits((int)(DotInternal(other) / k));
+        public I4F60 UncheckedDot(Vector4I2F30 other) {
+            return I4F60.FromBits(Repr.UncheckedDot(other.Repr));
         }
 
         // ベクトルの長さは符号つき、


### PR DESCRIPTION
内部的に行っていた除算を削除した。
その代わり、大きな値を与えた場合、オーバーフローが発生するようになった。
また、メソッド名を Dot から UncheckedDot に変更した。