### PR TITLE
Mathi.Atan2P9 削除

### DIFF
--- a/.generator/templates/Fixed.cs
+++ b/.generator/templates/Fixed.cs
@@ -353,25 +353,19 @@ namespace {{ namespace }} {
         {%- endif %}
 
         #region Atan2
-
         {%- if int_nbits+frac_nbits > 32 %}
 
         // Atan2 は 32 ビットの固定小数点数に対してのみ定義されている。
         // 実装のために 128 ビット整数が必要なため、
         // 64 ビットの固定小数点数に対しては未実装。
-
         {%- else %}
 
 #pragma warning disable IDE0079 // 不要な抑制を削除します
 #pragma warning disable IDE0002 // メンバー アクセスを単純化します
 
         {%- for order in [2, 3, 9] %}
-        {%- if order < 9 %}
-            {%- set f = 32-2 %}
-        {%- else %}
-            {%- set f = 64-2 %}
-        {%- endif %}
-        {%- set atan = macros::fixed_type(i=2, f=f, s=true) %}
+        {%- if order > 3 and int_nbits+frac_nbits < 64 %}{% continue %}{% endif %}
+        {%- set atan = macros::fixed_type(i=2, f=int_nbits+frac_nbits - 2, s=true) %}
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public {{ atan }} Atan2P{{ order }}({{ self_type }} other) {

--- a/Intar1991.Tests/Mathi/AtanTest.cs
+++ b/Intar1991.Tests/Mathi/AtanTest.cs
@@ -319,13 +319,16 @@ namespace Intar1991.Tests.Mathi {
             }
             Console.WriteLine($"max error: {max}");
         }
+
+#if false
+
         static void TestAtan2(
-            Func<int, int, long> atan2,
-            Func<int, long> atan, double error) {
+            Func<long, long, long> atan2,
+            Func<long, long> atan, double error) {
             const long pi = 1L << 62;
-            for (var i = 1; i <= 32768; ++i) {
-                const int k1 = 1 << 16;
-                const int k2 = -k1;
+            for (var i = 1L; i <= 1L << 31; i += 1024) {
+                const long k1 = 1L << 32;
+                const long k2 = -k1;
                 const long k3 = pi / 2;
                 var expected1 = atan(i);
                 var expected4 = -expected1;
@@ -360,8 +363,8 @@ namespace Intar1991.Tests.Mathi {
             var rng = new Intar1991.Rand.Xoroshiro128StarStar(1, 2);
             var max = 0.0;
             for (var i = 0; i < 32768; ++i) {
-                var x = rng.Next();
-                var y = rng.Next();
+                var x = rng.NextInt64();
+                var y = rng.NextInt64();
                 var expected = Math.Atan2(y, x);
                 var actual = atan2(y, x);
                 Utility.AssertAreEqual(expected, actual * toRad, error);
@@ -370,8 +373,18 @@ namespace Intar1991.Tests.Mathi {
             Console.WriteLine($"max error: {max}");
         }
 
+#endif
+
         [Test] public static void TestAtan2P2() => TestAtan2(Intar1991.Mathi.Atan2P2, Intar1991.Mathi.AtanP2, 0.0039);
         [Test] public static void TestAtan2P3() => TestAtan2(Intar1991.Mathi.Atan2P3, Intar1991.Mathi.AtanP3, 0.0016);
-        [Test] public static void TestAtan2P9() => TestAtan2(Intar1991.Mathi.Atan2P9, a => Intar1991.Mathi.AtanP9((long)a << 16), 0.00003);
+
+#if false
+
+        [Test] public static void TestAtan2P2L() => TestAtan2(Intar1991.Mathi.Atan2P2, Intar1991.Mathi.AtanP2, 0.0039);
+        [Test] public static void TestAtan2P3L() => TestAtan2(Intar1991.Mathi.Atan2P3, Intar1991.Mathi.AtanP3, 0.0016);
+        [Test] public static void TestAtan2P9L() => TestAtan2(Intar1991.Mathi.Atan2P9, Intar1991.Mathi.AtanP9, 0.00002);
+
+#endif
+
     }
 }

--- a/Intar1991/I17F15.gen.cs
+++ b/Intar1991/I17F15.gen.cs
@@ -244,11 +244,6 @@ namespace Intar1991 {
             return I2F30.FromBits(Mathi.Atan2P3(Bits, other.Bits));
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P9(I17F15 other) {
-            return I2F62.FromBits(Mathi.Atan2P9(Bits, other.Bits));
-        }
-
 #pragma warning restore IDE0002 // メンバー アクセスを単純化します
 #pragma warning restore IDE0079 // 不要な抑制を削除します
 

--- a/Intar1991/I2F30.gen.cs
+++ b/Intar1991/I2F30.gen.cs
@@ -228,11 +228,6 @@ namespace Intar1991 {
             return I2F30.FromBits(Mathi.Atan2P3(Bits, other.Bits));
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P9(I2F30 other) {
-            return I2F62.FromBits(Mathi.Atan2P9(Bits, other.Bits));
-        }
-
 #pragma warning restore IDE0002 // メンバー アクセスを単純化します
 #pragma warning restore IDE0079 // 不要な抑制を削除します
 

--- a/Intar1991/Mathi.gen.cs
+++ b/Intar1991/Mathi.gen.cs
@@ -586,7 +586,7 @@ namespace Intar1991 {
         /// <code>
         /// var actual = Intar1991.Mathi.Atan2P2(2, 3);
         /// var expected = System.Math.Atan2(2, 3);
-        /// Assert.AreEqual(expected, actual * toRad, 0.004);
+        /// Assert.AreEqual(expected, actual * toRad, 0.0039);
         /// </code>
         /// </example>
         /// </summary>
@@ -633,7 +633,7 @@ namespace Intar1991 {
         /// <code>
         /// var actual = Intar1991.Mathi.Atan2P3(2, 3);
         /// var expected = System.Math.Atan2(2, 3);
-        /// Assert.AreEqual(expected, actual * toRad, 0.0017);
+        /// Assert.AreEqual(expected, actual * toRad, 0.0016);
         /// </code>
         /// </example>
         /// </summary>
@@ -666,53 +666,6 @@ namespace Intar1991 {
                     return y > x
                         ? right - AtanInternal.P3(AtanInternal.Div(x, y))
                         : AtanInternal.P3(AtanInternal.Div(y, x));
-                } else {
-                    return right;
-                }
-            } else {
-                return x < 0 ? straight : 0;
-            }
-        }
-
-        /// <summary>
-        /// 9 次の多項式で逆正接を近似する。
-        /// <example>
-        /// <code>
-        /// var actual = Intar1991.Mathi.Atan2P9(2, 3);
-        /// var expected = System.Math.Atan2(2, 3);
-        /// Assert.AreEqual(expected, actual * toRad, 0.00003);
-        /// </code>
-        /// </example>
-        /// </summary>
-        /// <param name="y">Y 座標</param>
-        /// <param name="x">X 座標</param>
-        /// <returns>2 の 62 乗を PI とする逆正接</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long Atan2P9(int y, int x) {
-            const long straight = 1L << 62;
-            const long right = straight / 2;
-            const long rightNeg = -right;
-            if (y < 0) {
-                if (x < 0) {
-                    return y < x
-                        ? rightNeg - AtanInternal.P9((long)AtanInternal.Div(x, y) << 16)
-                        : AtanInternal.P9((long)AtanInternal.Div(y, x) << 16) - straight;
-                } else if (x > 0) {
-                    return y < -x
-                        ? rightNeg - AtanInternal.P9((long)AtanInternal.Div(x, y) << 16)
-                        : AtanInternal.P9((long)AtanInternal.Div(y, x) << 16);
-                } else {
-                    return rightNeg;
-                }
-            } else if (y > 0) {
-                if (x < 0) {
-                    return -y < x
-                        ? right - AtanInternal.P9((long)AtanInternal.Div(x, y) << 16)
-                        : straight + AtanInternal.P9((long)AtanInternal.Div(y, x) << 16);
-                } else if (x > 0) {
-                    return y > x
-                        ? right - AtanInternal.P9((long)AtanInternal.Div(x, y) << 16)
-                        : AtanInternal.P9((long)AtanInternal.Div(y, x) << 16);
                 } else {
                     return right;
                 }


### PR DESCRIPTION
Mathi.Atan2P9 が int を引数としていたのは
設計上の誤りであったため, これを削除した.