### PR TITLE
整数から固定小数点数への変換を簡略化

### DIFF
--- a/Intar/I17F15.gen.cs
+++ b/Intar/I17F15.gen.cs
@@ -402,305 +402,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.StrictFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 StrictFrom(int num) {
-            return FromBits(checked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 UncheckedFrom(int num) {
-            return FromBits(unchecked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.CheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15? CheckedFrom(int num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I17F15(int num) {
             return FromBits((int)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.StrictFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 StrictFrom(uint num) {
-            return FromBits(checked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 UncheckedFrom(uint num) {
-            return FromBits(unchecked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.CheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15? CheckedFrom(uint num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (uint)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I17F15(uint num) {
             return FromBits((int)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.StrictFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 StrictFrom(long num) {
-            return FromBits(checked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 UncheckedFrom(long num) {
-            return FromBits(unchecked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.CheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15? CheckedFrom(long num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I17F15(long num) {
             return FromBits((int)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.StrictFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 StrictFrom(ulong num) {
-            return FromBits(checked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.CheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15? CheckedFrom(ulong num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (uint)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I17F15(ulong num) {
             return FromBits((int)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I17F15(Int128 num) {
+            return FromBits((int)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I17F15(UInt128 num) {
+            return FromBits((int)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/I2F30.gen.cs
+++ b/Intar/I2F30.gen.cs
@@ -252,305 +252,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 StrictFrom(int num) {
-            return FromBits(checked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 UncheckedFrom(int num) {
-            return FromBits(unchecked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30? CheckedFrom(int num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I2F30(int num) {
             return FromBits((int)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 StrictFrom(uint num) {
-            return FromBits(checked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 UncheckedFrom(uint num) {
-            return FromBits(unchecked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30? CheckedFrom(uint num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (uint)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I2F30(uint num) {
             return FromBits((int)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 StrictFrom(long num) {
-            return FromBits(checked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 UncheckedFrom(long num) {
-            return FromBits(unchecked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30? CheckedFrom(long num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I2F30(long num) {
             return FromBits((int)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 StrictFrom(ulong num) {
-            return FromBits(checked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((int)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30? CheckedFrom(ulong num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (uint)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I2F30(ulong num) {
             return FromBits((int)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I2F30(Int128 num) {
+            return FromBits((int)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I2F30(UInt128 num) {
+            return FromBits((int)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/I2F62.gen.cs
+++ b/Intar/I2F62.gen.cs
@@ -267,305 +267,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 StrictFrom(int num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 UncheckedFrom(int num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62? CheckedFrom(int num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I2F62(int num) {
             return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 StrictFrom(uint num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 UncheckedFrom(uint num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62? CheckedFrom(uint num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (ulong)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I2F62(uint num) {
             return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 StrictFrom(long num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 UncheckedFrom(long num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62? CheckedFrom(long num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I2F62(long num) {
             return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 StrictFrom(ulong num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62? CheckedFrom(ulong num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (ulong)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I2F62(ulong num) {
             return FromBits((long)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I2F62(Int128 num) {
+            return FromBits((long)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I2F62(UInt128 num) {
+            return FromBits((long)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/I33F31.gen.cs
+++ b/Intar/I33F31.gen.cs
@@ -494,194 +494,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.From(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 From(int num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator I33F31(int num) {
+            return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.From(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 From(uint num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator I33F31(uint num) {
+            return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 StrictFrom(long num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 UncheckedFrom(long num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31? CheckedFrom(long num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I33F31(long num) {
             return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 StrictFrom(ulong num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31? CheckedFrom(ulong num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (ulong)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I33F31(ulong num) {
             return FromBits((long)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I33F31(Int128 num) {
+            return FromBits((long)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I33F31(UInt128 num) {
+            return FromBits((long)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/I34F30.gen.cs
+++ b/Intar/I34F30.gen.cs
@@ -266,194 +266,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.From(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 From(int num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator I34F30(int num) {
+            return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.From(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 From(uint num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator I34F30(uint num) {
+            return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 StrictFrom(long num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 UncheckedFrom(long num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30? CheckedFrom(long num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I34F30(long num) {
             return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 StrictFrom(ulong num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30? CheckedFrom(ulong num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (ulong)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I34F30(ulong num) {
             return FromBits((long)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I34F30(Int128 num) {
+            return FromBits((long)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I34F30(UInt128 num) {
+            return FromBits((long)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/I4F60.gen.cs
+++ b/Intar/I4F60.gen.cs
@@ -266,305 +266,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 StrictFrom(int num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 UncheckedFrom(int num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60? CheckedFrom(int num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I4F60(int num) {
             return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 StrictFrom(uint num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 UncheckedFrom(uint num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60? CheckedFrom(uint num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (ulong)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I4F60(uint num) {
             return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 StrictFrom(long num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 UncheckedFrom(long num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60? CheckedFrom(long num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I4F60(long num) {
             return FromBits((long)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.StrictFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 StrictFrom(ulong num) {
-            return FromBits(checked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((long)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.CheckedFrom(1);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60? CheckedFrom(ulong num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (ulong)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I4F60(ulong num) {
             return FromBits((long)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I4F60(Int128 num) {
+            return FromBits((long)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I4F60(UInt128 num) {
+            return FromBits((long)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/I68F60.gen.cs
+++ b/Intar/I68F60.gen.cs
@@ -187,83 +187,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I68F60.From(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I68F60 From(int num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator I68F60(int num) {
+            return FromBits((Int128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I68F60.From(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I68F60 From(uint num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator I68F60(uint num) {
+            return FromBits((Int128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I68F60.From(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I68F60 From(long num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator I68F60(long num) {
+            return FromBits((Int128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I68F60.From(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I68F60 From(ulong num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator I68F60(ulong num) {
+            return FromBits((Int128)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I68F60(Int128 num) {
+            return FromBits((Int128)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I68F60(UInt128 num) {
+            return FromBits((Int128)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/I8F120.gen.cs
+++ b/Intar/I8F120.gen.cs
@@ -187,305 +187,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.StrictFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 StrictFrom(int num) {
-            return FromBits(checked((Int128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.UncheckedFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 UncheckedFrom(int num) {
-            return FromBits(unchecked((Int128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.CheckedFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120? CheckedFrom(int num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I8F120(int num) {
             return FromBits((Int128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.StrictFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 StrictFrom(uint num) {
-            return FromBits(checked((Int128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.UncheckedFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 UncheckedFrom(uint num) {
-            return FromBits(unchecked((Int128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.CheckedFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120? CheckedFrom(uint num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (UInt128)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I8F120(uint num) {
             return FromBits((Int128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.StrictFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 StrictFrom(long num) {
-            return FromBits(checked((Int128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.UncheckedFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 UncheckedFrom(long num) {
-            return FromBits(unchecked((Int128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.CheckedFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120? CheckedFrom(long num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator I8F120(long num) {
             return FromBits((Int128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.StrictFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 StrictFrom(ulong num) {
-            return FromBits(checked((Int128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.UncheckedFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((Int128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.CheckedFrom(1);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120? CheckedFrom(ulong num) {
-
-            // 自身が符号あり、相手が符号なしであるから、
-            // 相手が最小値未満であることはありえない。
-            // よって、自身の最大値を符号なしの型に変換して比較する。
-            // この際、大きい方の型に暗黙に変換される。
-            if (num > (UInt128)(MaxRepr / OneRepr)) {
-                return null;
-            }
-
+        public static explicit operator I8F120(ulong num) {
             return FromBits((Int128)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I8F120(Int128 num) {
+            return FromBits((Int128)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator I8F120(UInt128 num) {
+            return FromBits((Int128)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/U17F15.gen.cs
+++ b/Intar/U17F15.gen.cs
@@ -206,307 +206,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.StrictFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 StrictFrom(int num) {
-            return FromBits(checked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 UncheckedFrom(int num) {
-            return FromBits(unchecked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.CheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15? CheckedFrom(int num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((uint)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U17F15(int num) {
             return FromBits((uint)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.StrictFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 StrictFrom(uint num) {
-            return FromBits(checked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 UncheckedFrom(uint num) {
-            return FromBits(unchecked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.CheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15? CheckedFrom(uint num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U17F15(uint num) {
             return FromBits((uint)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.StrictFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 StrictFrom(long num) {
-            return FromBits(checked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 UncheckedFrom(long num) {
-            return FromBits(unchecked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.CheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15? CheckedFrom(long num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((ulong)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U17F15(long num) {
             return FromBits((uint)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.StrictFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 StrictFrom(ulong num) {
-            return FromBits(checked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.CheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15? CheckedFrom(ulong num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U17F15(ulong num) {
             return FromBits((uint)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U17F15(Int128 num) {
+            return FromBits((uint)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U17F15(UInt128 num) {
+            return FromBits((uint)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/U2F30.gen.cs
+++ b/Intar/U2F30.gen.cs
@@ -206,307 +206,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 StrictFrom(int num) {
-            return FromBits(checked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 UncheckedFrom(int num) {
-            return FromBits(unchecked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30? CheckedFrom(int num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((uint)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U2F30(int num) {
             return FromBits((uint)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 StrictFrom(uint num) {
-            return FromBits(checked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 UncheckedFrom(uint num) {
-            return FromBits(unchecked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30? CheckedFrom(uint num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U2F30(uint num) {
             return FromBits((uint)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 StrictFrom(long num) {
-            return FromBits(checked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 UncheckedFrom(long num) {
-            return FromBits(unchecked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30? CheckedFrom(long num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((ulong)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U2F30(long num) {
             return FromBits((uint)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 StrictFrom(ulong num) {
-            return FromBits(checked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((uint)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30? CheckedFrom(ulong num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U2F30(ulong num) {
             return FromBits((uint)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U2F30(Int128 num) {
+            return FromBits((uint)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U2F30(UInt128 num) {
+            return FromBits((uint)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/U2F62.gen.cs
+++ b/Intar/U2F62.gen.cs
@@ -207,307 +207,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 StrictFrom(int num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 UncheckedFrom(int num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62? CheckedFrom(int num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((uint)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U2F62(int num) {
             return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 StrictFrom(uint num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 UncheckedFrom(uint num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62? CheckedFrom(uint num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U2F62(uint num) {
             return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 StrictFrom(long num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 UncheckedFrom(long num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62? CheckedFrom(long num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((ulong)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U2F62(long num) {
             return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 StrictFrom(ulong num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62? CheckedFrom(ulong num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U2F62(ulong num) {
             return FromBits((ulong)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U2F62(Int128 num) {
+            return FromBits((ulong)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U2F62(UInt128 num) {
+            return FromBits((ulong)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/U33F31.gen.cs
+++ b/Intar/U33F31.gen.cs
@@ -207,252 +207,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 StrictFrom(int num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 UncheckedFrom(int num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31? CheckedFrom(int num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((uint)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U33F31(int num) {
             return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.From(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 From(uint num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator U33F31(uint num) {
+            return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 StrictFrom(long num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 UncheckedFrom(long num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31? CheckedFrom(long num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((ulong)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U33F31(long num) {
             return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 StrictFrom(ulong num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31? CheckedFrom(ulong num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U33F31(ulong num) {
             return FromBits((ulong)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U33F31(Int128 num) {
+            return FromBits((ulong)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U33F31(UInt128 num) {
+            return FromBits((ulong)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/U34F30.gen.cs
+++ b/Intar/U34F30.gen.cs
@@ -221,252 +221,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 StrictFrom(int num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 UncheckedFrom(int num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30? CheckedFrom(int num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((uint)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U34F30(int num) {
             return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.From(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 From(uint num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator U34F30(uint num) {
+            return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 StrictFrom(long num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 UncheckedFrom(long num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30? CheckedFrom(long num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((ulong)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U34F30(long num) {
             return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 StrictFrom(ulong num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30? CheckedFrom(ulong num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U34F30(ulong num) {
             return FromBits((ulong)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U34F30(Int128 num) {
+            return FromBits((ulong)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U34F30(UInt128 num) {
+            return FromBits((ulong)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/U4F60.gen.cs
+++ b/Intar/U4F60.gen.cs
@@ -221,307 +221,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 StrictFrom(int num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 UncheckedFrom(int num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60? CheckedFrom(int num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((uint)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U4F60(int num) {
             return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 StrictFrom(uint num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 UncheckedFrom(uint num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60? CheckedFrom(uint num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U4F60(uint num) {
             return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 StrictFrom(long num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 UncheckedFrom(long num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60? CheckedFrom(long num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((ulong)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U4F60(long num) {
             return FromBits((ulong)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.StrictFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 StrictFrom(ulong num) {
-            return FromBits(checked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.UncheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((ulong)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.CheckedFrom(1);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60? CheckedFrom(ulong num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U4F60(ulong num) {
             return FromBits((ulong)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U4F60(Int128 num) {
+            return FromBits((ulong)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U4F60(UInt128 num) {
+            return FromBits((ulong)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/U68F60.gen.cs
+++ b/Intar/U68F60.gen.cs
@@ -171,197 +171,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.StrictFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60 StrictFrom(int num) {
-            return FromBits(checked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.UncheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60 UncheckedFrom(int num) {
-            return FromBits(unchecked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.CheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60? CheckedFrom(int num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((uint)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U68F60(int num) {
             return FromBits((UInt128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.From(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60 From(uint num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator U68F60(uint num) {
+            return FromBits((UInt128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.StrictFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60 StrictFrom(long num) {
-            return FromBits(checked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.UncheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60 UncheckedFrom(long num) {
-            return FromBits(unchecked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.CheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60? CheckedFrom(long num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((ulong)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U68F60(long num) {
             return FromBits((UInt128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.From(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60 From(ulong num) {
-            // 自身と相手の符号が同じ場合、整数部が相手以上であるから乗算は必ず成功する。
-            // 自身が符号あり、相手が符号なしの場合、
-            // 自身の符号部分を除いた整数部について同様である。
-            return FromBits(unchecked(num * OneRepr));
+        public static explicit operator U68F60(ulong num) {
+            return FromBits((UInt128)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U68F60(Int128 num) {
+            return FromBits((UInt128)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U68F60(UInt128 num) {
+            return FromBits((UInt128)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 

--- a/Intar/U8F120.gen.cs
+++ b/Intar/U8F120.gen.cs
@@ -171,307 +171,59 @@ namespace Intar {
 #pragma warning disable CS0652 // 整数定数への比較は無意味です。定数が型の範囲外です
 #pragma warning disable IDE0004 // 不要なキャストの削除
 
-        #region Convert from integer
+        #region Conversion from integer
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.StrictFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 StrictFrom(int num) {
-            return FromBits(checked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="CheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.UncheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 UncheckedFrom(int num) {
-            return FromBits(unchecked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="int" /> value.</para>
-        /// <para><see cref="int" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(int)"/>
-        /// <seealso cref="UncheckedFrom(int)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.CheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120? CheckedFrom(int num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((uint)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U8F120(int num) {
             return FromBits((UInt128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.StrictFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 StrictFrom(uint num) {
-            return FromBits(checked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="CheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.UncheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 UncheckedFrom(uint num) {
-            return FromBits(unchecked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="uint" /> value.</para>
-        /// <para><see cref="uint" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(uint)"/>
-        /// <seealso cref="UncheckedFrom(uint)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.CheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120? CheckedFrom(uint num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U8F120(uint num) {
             return FromBits((UInt128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.StrictFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 StrictFrom(long num) {
-            return FromBits(checked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="CheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.UncheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 UncheckedFrom(long num) {
-            return FromBits(unchecked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="long" /> value.</para>
-        /// <para><see cref="long" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(long)"/>
-        /// <seealso cref="UncheckedFrom(long)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.CheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120? CheckedFrom(long num) {
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 相手が 0 未満、または
-            // 相手が自身の最大値よりも大きければ null
-            if (num < 0) {
-                return null;
-            } else if ((ulong)num > MaxRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U8F120(long num) {
             return FromBits((UInt128)num * OneRepr);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.StrictFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 StrictFrom(ulong num) {
-            return FromBits(checked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="CheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.UncheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 UncheckedFrom(ulong num) {
-            return FromBits(unchecked((UInt128)num * OneRepr));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="ulong" /> value.</para>
-        /// <para><see cref="ulong" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(ulong)"/>
-        /// <seealso cref="UncheckedFrom(ulong)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.CheckedFrom(1);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a?.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120? CheckedFrom(ulong num) {
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (num > MaxRepr / OneRepr ||
-                num < MinRepr / OneRepr) {
-                return null;
-            }
-
+        public static explicit operator U8F120(ulong num) {
             return FromBits((UInt128)num * OneRepr);
         }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="Int128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U8F120(Int128 num) {
+            return FromBits((UInt128)num * OneRepr);
+        }
+
+        /// <summary>
+        /// <para>Constructs a new fixed-point number from <see cref="UInt128" /> value.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator U8F120(UInt128 num) {
+            return FromBits((UInt128)num * OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
 
         #endregion
 


### PR DESCRIPTION
From, StrictFrom, UncheckedFrom, CheckedFrom などの
専用の静的メソッドを廃止し, 一般的な C# の
変換演算子のインタフェースに変更した.

これは, 実際にはオーバーフローが発生することは稀であり,
それらを厳密に取り扱うためのメソッドは過剰であるという判断である.