### PR TITLE
浮動小数点数から固定小数点数への変換を簡略化

### DIFF
--- a/Intar.Tests/AffineTransformTest.cs
+++ b/Intar.Tests/AffineTransformTest.cs
@@ -78,14 +78,12 @@ namespace Intar.Tests {
 
         static readonly AffineTransform3I17F15 sample = new AffineTransform3I17F15(
             new Matrix3x3I17F15(
-                new Vector3I17F15(I17F15.StrictFrom(1), I17F15.StrictFrom(2), I17F15.StrictFrom(3)),
-                new Vector3I17F15(I17F15.StrictFrom(4), I17F15.StrictFrom(5), I17F15.StrictFrom(6)),
-                new Vector3I17F15(I17F15.StrictFrom(7), I17F15.StrictFrom(8), I17F15.StrictFrom(9))),
-            new Vector3I17F15(I17F15.StrictFrom(10), I17F15.StrictFrom(11), I17F15.StrictFrom(12)));
+                new Vector3I17F15((I17F15)1, (I17F15)2, (I17F15)3),
+                new Vector3I17F15((I17F15)4, (I17F15)5, (I17F15)6),
+                new Vector3I17F15((I17F15)7, (I17F15)8, (I17F15)9)),
+            new Vector3I17F15((I17F15)10, (I17F15)11, (I17F15)12));
         static readonly Vector3I17F15 samplePosition = new Vector3I17F15(
-            I17F15.StrictFrom(13),
-            I17F15.StrictFrom(14),
-            I17F15.StrictFrom(15));
+            (I17F15)13, (I17F15)14, (I17F15)15);
         static readonly Vector3I17F15 sampleTransformedPosition = sample * samplePosition;
 
         [Test]
@@ -119,10 +117,10 @@ namespace Intar.Tests {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static AffineTransform3I17F15 Trs(Vector3I17F15 translation, System.Numerics.Quaternion rotation, Vector3I17F15 scale) {
             return AffineTransform3I17F15.Trs(translation, new QuaternionI2F30(
-                I2F30.StrictFrom(rotation.X),
-                I2F30.StrictFrom(rotation.Y),
-                I2F30.StrictFrom(rotation.Z),
-                I2F30.StrictFrom(rotation.W)), scale);
+                (I2F30)rotation.X,
+                (I2F30)rotation.Y,
+                (I2F30)rotation.Z,
+                (I2F30)rotation.W), scale);
         }
 
         [Test]

--- a/Intar.Tests/FixedTest.cs
+++ b/Intar.Tests/FixedTest.cs
@@ -6,8 +6,8 @@ namespace Intar.Tests {
     public class FixedTest {
         [Test]
         public static void Test() {
-            var a = I17F15.CheckedFrom(1).Value;
-            var b = I17F15.CheckedFrom(2).Value;
+            var a = (I17F15)1;
+            var b = (I17F15)2;
             a += b;
             Utility.AssertAreEqual(3, a.ToInt32());
         }
@@ -15,34 +15,8 @@ namespace Intar.Tests {
         [Test]
         public static void TestFromNum() {
             const float f = 65539.9f / 65536;
-            Assert.AreEqual(32769, I17F15.CheckedLossyFrom(f)?.Bits);
-            Assert.AreEqual(-32769, I17F15.CheckedLossyFrom(-f)?.Bits);
-        }
-
-        [Test]
-        public static void TestStrictFromNum() {
-            _ = Assert.Throws<OverflowException>(() => I17F15.StrictFrom(int.MaxValue));
-            _ = Assert.Throws<OverflowException>(() => I2F30.StrictFrom(2.0f));
-            _ = Assert.Throws<OverflowException>(() => I2F30.StrictLossyFrom(2.0));
-            _ = Assert.Throws<OverflowException>(() => I2F30.StrictFrom(float.NegativeInfinity));
-            _ = Assert.Throws<OverflowException>(() => I2F30.StrictFrom(float.PositiveInfinity));
-            _ = Assert.Throws<OverflowException>(() => I2F30.StrictFrom(float.NaN));
-        }
-
-        [Test]
-        public static void TestCheckedFromNum() {
-            Assert.AreEqual(int.MinValue, I2F30.CheckedFrom(-2.0f)?.Bits);
-            Assert.AreEqual(null, I2F30.CheckedFrom(2));
-            Assert.AreEqual(null, I2F30.CheckedFrom(2.0f));
-            Assert.AreEqual(null, I2F30.CheckedFrom(-2.000001f));
-            Assert.AreEqual(null, I2F30.CheckedFrom(-3));
-            Assert.AreEqual(null, I17F15.CheckedFrom(float.NegativeInfinity));
-            Assert.AreEqual(null, I17F15.CheckedFrom(float.PositiveInfinity));
-            Assert.AreEqual(null, I17F15.CheckedFrom(float.NaN));
-            Assert.AreEqual(null, I17F15.CheckedLossyFrom(double.NegativeInfinity));
-            Assert.AreEqual(null, I17F15.CheckedLossyFrom(double.PositiveInfinity));
-            Assert.AreEqual(null, I17F15.CheckedLossyFrom(double.NaN));
-            Assert.AreEqual(null, I17F15.CheckedFrom(65536.0f));
+            Assert.AreEqual(32769, ((I17F15)f).Bits);
+            Assert.AreEqual(-32769, ((I17F15)(-f)).Bits);
         }
     }
 }

--- a/Intar/I17F15.gen.cs
+++ b/Intar/I17F15.gen.cs
@@ -458,166 +458,30 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <seealso cref="CheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I17F15(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((int)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <seealso cref="CheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((int)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.CheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15? CheckedFrom(float num) {
-            // より大きい型に変換して計算。
-            return CheckedLossyFrom(num);
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((int)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(double)"/>
-        /// <seealso cref="CheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.StrictLossyFrom(1.0);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 StrictLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I17F15(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((int)(num * (double)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(double)"/>
-        /// <seealso cref="CheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.UncheckedLossyFrom(1.0);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15 UncheckedLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((int)(num * (double)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(double)"/>
-        /// <seealso cref="UncheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I17F15.CheckedLossyFrom(1.0);
-        /// System.Assert.AreEqual(1 &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I17F15? CheckedLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            // また、整数の基数は 2 であるから、
-            // 自身のビット数よりも相手の仮数部の方が大きい限り、
-            // 最大値に 1 足した数と最小値から 1 引いた数は厳密に表現可能である。
-            num *= OneRepr;
-            if (double.IsNaN(num) ||
-                double.IsInfinity(num) ||
-                num >= int.MaxValue + 1.0 ||
-                num <= int.MinValue - 1.0) {
-                return null;
-            }
-            return FromBits((int)num);
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((int)(num * (double)OneRepr)));
         }
 
         #endregion

--- a/Intar/I2F30.gen.cs
+++ b/Intar/I2F30.gen.cs
@@ -308,166 +308,30 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <seealso cref="CheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I2F30(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((int)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <seealso cref="CheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((int)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.CheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30? CheckedFrom(float num) {
-            // より大きい型に変換して計算。
-            return CheckedLossyFrom(num);
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((int)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(double)"/>
-        /// <seealso cref="CheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.StrictLossyFrom(1.0);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 StrictLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I2F30(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((int)(num * (double)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(double)"/>
-        /// <seealso cref="CheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.UncheckedLossyFrom(1.0);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30 UncheckedLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((int)(num * (double)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(double)"/>
-        /// <seealso cref="UncheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F30.CheckedLossyFrom(1.0);
-        /// System.Assert.AreEqual(1 &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F30? CheckedLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            // また、整数の基数は 2 であるから、
-            // 自身のビット数よりも相手の仮数部の方が大きい限り、
-            // 最大値に 1 足した数と最小値から 1 引いた数は厳密に表現可能である。
-            num *= OneRepr;
-            if (double.IsNaN(num) ||
-                double.IsInfinity(num) ||
-                num >= int.MaxValue + 1.0 ||
-                num <= int.MinValue - 1.0) {
-                return null;
-            }
-            return FromBits((int)num);
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((int)(num * (double)OneRepr)));
         }
 
         #endregion

--- a/Intar/I2F62.gen.cs
+++ b/Intar/I2F62.gen.cs
@@ -323,113 +323,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I2F62(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((long)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((long)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.StrictFrom(1.0);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((long)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((long)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I2F62.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual(1L &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I2F62 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I2F62(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((long)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((long)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/I33F31.gen.cs
+++ b/Intar/I33F31.gen.cs
@@ -550,113 +550,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I33F31(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((long)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((long)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.StrictFrom(1.0);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((long)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((long)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I33F31.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual(1L &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I33F31 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I33F31(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((long)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((long)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/I34F30.gen.cs
+++ b/Intar/I34F30.gen.cs
@@ -322,113 +322,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I34F30(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((long)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((long)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.StrictFrom(1.0);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((long)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((long)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I34F30.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual(1L &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I34F30 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I34F30(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((long)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((long)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/I4F60.gen.cs
+++ b/Intar/I4F60.gen.cs
@@ -322,113 +322,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I4F60(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((long)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((long)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.StrictFrom(1.0);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((long)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((long)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I4F60.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual(1L &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I4F60 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I4F60(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((long)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((long)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/I68F60.gen.cs
+++ b/Intar/I68F60.gen.cs
@@ -243,113 +243,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I68F60.StrictFrom(1.0f);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I68F60 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I68F60(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((Int128)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I68F60.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I68F60 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((Int128)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I68F60.StrictFrom(1.0);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I68F60 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((Int128)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((Int128)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I68F60.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I68F60 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I68F60(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((Int128)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((Int128)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/I8F120.gen.cs
+++ b/Intar/I8F120.gen.cs
@@ -243,113 +243,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.StrictFrom(1.0f);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I8F120(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((Int128)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((Int128)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.StrictFrom(1.0);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((Int128)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((Int128)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = I8F120.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual((Int128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static I8F120 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator I8F120(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((Int128)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((Int128)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/U17F15.gen.cs
+++ b/Intar/U17F15.gen.cs
@@ -262,165 +262,30 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <seealso cref="CheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U17F15(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((uint)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <seealso cref="CheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((uint)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.CheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15? CheckedFrom(float num) {
-            // より大きい型に変換して計算。
-            return CheckedLossyFrom(num);
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((uint)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(double)"/>
-        /// <seealso cref="CheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.StrictLossyFrom(1.0);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 StrictLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U17F15(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((uint)(num * (double)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(double)"/>
-        /// <seealso cref="CheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.UncheckedLossyFrom(1.0);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15 UncheckedLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((uint)(num * (double)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(double)"/>
-        /// <seealso cref="UncheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U17F15.CheckedLossyFrom(1.0);
-        /// System.Assert.AreEqual(1U &lt;&lt; 15, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U17F15? CheckedLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            // また、整数の基数は 2 であるから、
-            // 自身のビット数よりも相手の仮数部の方が大きい限り、
-            // 最大値に 1 足した数と最小値から 1 引いた数は厳密に表現可能である。
-            num *= OneRepr;
-            if (double.IsNaN(num) ||
-                double.IsInfinity(num) ||
-                num >= uint.MaxValue + 1.0) {
-                return null;
-            }
-            return FromBits((uint)num);
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((uint)(num * (double)OneRepr)));
         }
 
         #endregion

--- a/Intar/U2F30.gen.cs
+++ b/Intar/U2F30.gen.cs
@@ -262,165 +262,30 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <seealso cref="CheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U2F30(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((uint)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <seealso cref="CheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((uint)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.CheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30? CheckedFrom(float num) {
-            // より大きい型に変換して計算。
-            return CheckedLossyFrom(num);
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((uint)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(double)"/>
-        /// <seealso cref="CheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.StrictLossyFrom(1.0);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 StrictLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U2F30(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((uint)(num * (double)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(double)"/>
-        /// <seealso cref="CheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.UncheckedLossyFrom(1.0);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30 UncheckedLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((uint)(num * (double)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(double)"/>
-        /// <seealso cref="UncheckedLossyFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F30.CheckedLossyFrom(1.0);
-        /// System.Assert.AreEqual(1U &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F30? CheckedLossyFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            // また、整数の基数は 2 であるから、
-            // 自身のビット数よりも相手の仮数部の方が大きい限り、
-            // 最大値に 1 足した数と最小値から 1 引いた数は厳密に表現可能である。
-            num *= OneRepr;
-            if (double.IsNaN(num) ||
-                double.IsInfinity(num) ||
-                num >= uint.MaxValue + 1.0) {
-                return null;
-            }
-            return FromBits((uint)num);
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((uint)(num * (double)OneRepr)));
         }
 
         #endregion

--- a/Intar/U2F62.gen.cs
+++ b/Intar/U2F62.gen.cs
@@ -263,113 +263,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U2F62(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((ulong)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((ulong)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.StrictFrom(1.0);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((ulong)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((ulong)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U2F62.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 62, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U2F62 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U2F62(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((ulong)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((ulong)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/U33F31.gen.cs
+++ b/Intar/U33F31.gen.cs
@@ -263,113 +263,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U33F31(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((ulong)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((ulong)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.StrictFrom(1.0);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((ulong)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((ulong)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U33F31.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 31, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U33F31 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U33F31(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((ulong)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((ulong)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/U34F30.gen.cs
+++ b/Intar/U34F30.gen.cs
@@ -277,113 +277,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U34F30(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((ulong)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((ulong)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.StrictFrom(1.0);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((ulong)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((ulong)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U34F30.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 30, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U34F30 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U34F30(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((ulong)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((ulong)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/U4F60.gen.cs
+++ b/Intar/U4F60.gen.cs
@@ -277,113 +277,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.StrictFrom(1.0f);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U4F60(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((ulong)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((ulong)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.StrictFrom(1.0);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((ulong)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((ulong)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U4F60.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual(1UL &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U4F60 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U4F60(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((ulong)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((ulong)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/U68F60.gen.cs
+++ b/Intar/U68F60.gen.cs
@@ -227,113 +227,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.StrictFrom(1.0f);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U68F60(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((UInt128)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((UInt128)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.StrictFrom(1.0);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((UInt128)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((UInt128)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U68F60.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 60, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U68F60 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U68F60(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((UInt128)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((UInt128)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 

--- a/Intar/U8F120.gen.cs
+++ b/Intar/U8F120.gen.cs
@@ -227,113 +227,31 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from floating-point number
+        #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.StrictFrom(1.0f);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 StrictFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U8F120(float num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((UInt128)(num * (float)OneRepr)));
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="float" /> value.</para>
-        /// <para> <see cref="float" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(float)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.UncheckedFrom(1.0f);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 UncheckedFrom(float num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((UInt128)(num * (float)OneRepr)));
-        }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="UncheckedFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.StrictFrom(1.0);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 StrictFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
-            // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(checked((UInt128)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((UInt128)(num * (float)OneRepr)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="double" /> value.</para>
-        /// <para> <see cref="double" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="StrictFrom(double)"/>
-        /// <example>
-        /// Basic usage:
-        /// <code>
-        /// var a = U8F120.UncheckedFrom(1.0);
-        /// System.Assert.AreEqual((UInt128)1 &lt;&lt; 120, a.Bits);
-        /// </code>
-        /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static U8F120 UncheckedFrom(double num) {
-            // OneRepr は 2 の自然数冪であるから、
+        public static explicit operator U8F120(double num) {
+            // OneRepr は 2 の自然数冪であるから,
             // その乗算および型変換によって精度が失われることは
-            // 基数 (Radix) が 2 の自然数冪でない限りない。
-            return FromBits(unchecked((UInt128)(num * (double)OneRepr)));
+            // 基数 (Radix) が 2 の自然数冪でない限りない.
+            return FromBits(((UInt128)(num * (double)OneRepr)));
         }
-
-        // 自身が 64 ビットの場合､ BitConverter を使用する必要がある。
-        // 現時点では未実装。
-        // https://learn.microsoft.com/ja-jp/dotnet/api/system.bitconverter
 
         #endregion
 


### PR DESCRIPTION
StrictFrom, UncheckedFrom, CheckedFrom などの
専用の静的メソッドを廃止し, 一般的な C# の
変換演算子のインタフェースに変更した.

これは, 実際にはオーバーフローが発生することは稀であり,
それらを厳密に取り扱うためのメソッドは過剰であるという判断である.