### PR TITLE
固定小数点数から固定小数点数への変換を簡略化

### DIFF
--- a/.generator/templates/Matrix.cs
+++ b/.generator/templates/Matrix.cs
@@ -226,9 +226,8 @@ namespace {{ namespace }} {
                 {%- for i in range(end=cols) %}
                 new {{ col }}(
                     {%- for j in range(end=rows) %}
-                    {{ component }}.UncheckedLossyFrom({# -#}
-                        left.R{{ j }}.Dot(right.C{{ i }})
-                    {#- #}){% if not loop.last %},{% endif %}
+                    ({{ component }})left.R{{ j }}.Dot(right.C{{ i }})
+                    {%- if not loop.last %},{% endif %}
                     {%- endfor %}
                 ){%- if not loop.last %},{% endif %}
                 {%- endfor %}

--- a/.generator/templates/Quaternion.cs
+++ b/.generator/templates/Quaternion.cs
@@ -297,15 +297,15 @@ namespace {{ namespace }} {
                 // その後, 後の計算のために小数部の精度を {{ (int_nbits+frac_nbits-2)/2 }} ビットにする.
                 {#- 32 ビットのクォータニオンには AcosP3(long) を,
                     64 ビットのクォータニオンには AcosP7(Int128) を使用する. #}
-                var angle = {{
+                var angle = ({{
                     macros::fixed_type(s=true, i=(int_nbits+frac_nbits)/2 + 1, f=(int_nbits+frac_nbits)/2 - 1)
-                }}.LossyFrom({{
+                }}){{
                     macros::fixed_type(s=true, i=int_nbits+frac_nbits+1, f=int_nbits+frac_nbits-1)
                 }}.AcosP{%
                     if   int_nbits + frac_nbits == 32 %}3{%
                     elif int_nbits + frac_nbits == 64 %}7{%
                     else %}{{ throw(message='unimplemented') }}{%
-                    endif %}(({{ wide_bits }})d.Bits));
+                    endif %}(({{ wide_bits }})d.Bits);
 
                 // 閾値が 0.0005 の場合 invSin の最大値は
                 // (1 - (1-0.0005)^2)^(-0.5)=31.6267301900746 となる.

--- a/Intar/I17F15.gen.cs
+++ b/Intar/I17F15.gen.cs
@@ -486,182 +486,50 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I17F15 LossyFrom(I2F30 from) {
-            return FromBits(unchecked((int)(from.Bits / (I2F30.EpsilonRepr << 15)))
-            );
+        public static explicit operator I17F15(I2F30 from) {
+            return FromBits((int)(from.Bits / (I2F30.EpsilonRepr << 15)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I34F30)"/>
-        /// <seealso cref="CheckedLossyFrom(I34F30)"/>
-        public static I17F15 StrictLossyFrom(I34F30 from) {
-            return FromBits(checked((int)(from.Bits / (I34F30.EpsilonRepr << 15)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I34F30)"/>
-        /// <seealso cref="CheckedLossyFrom(I34F30)"/>
-        public static I17F15 UncheckedLossyFrom(I34F30 from) {
-            return FromBits(unchecked((int)(from.Bits / (I34F30.EpsilonRepr << 15)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I34F30)"/>
-        /// <seealso cref="UncheckedLossyFrom(I34F30)"/>
-        public static I17F15? CheckedLossyFrom(I34F30 from) {
-            var tmp = from.Bits / (I34F30.EpsilonRepr << 15);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I17F15(I34F30 from) {
+            return FromBits((int)(from.Bits / (I34F30.EpsilonRepr << 15)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(I33F31)"/>
-        public static I17F15 StrictLossyFrom(I33F31 from) {
-            return FromBits(checked((int)(from.Bits / (I33F31.EpsilonRepr << 16)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(I33F31)"/>
-        public static I17F15 UncheckedLossyFrom(I33F31 from) {
-            return FromBits(unchecked((int)(from.Bits / (I33F31.EpsilonRepr << 16)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I33F31)"/>
-        /// <seealso cref="UncheckedLossyFrom(I33F31)"/>
-        public static I17F15? CheckedLossyFrom(I33F31 from) {
-            var tmp = from.Bits / (I33F31.EpsilonRepr << 16);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I17F15(I33F31 from) {
+            return FromBits((int)(from.Bits / (I33F31.EpsilonRepr << 16)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I17F15 LossyFrom(I4F60 from) {
-            return FromBits(unchecked((int)(from.Bits / (I4F60.EpsilonRepr << 45)))
-            );
+        public static explicit operator I17F15(I4F60 from) {
+            return FromBits((int)(from.Bits / (I4F60.EpsilonRepr << 45)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I17F15 LossyFrom(I2F62 from) {
-            return FromBits(unchecked((int)(from.Bits / (I2F62.EpsilonRepr << 47)))
-            );
+        public static explicit operator I17F15(I2F62 from) {
+            return FromBits((int)(from.Bits / (I2F62.EpsilonRepr << 47)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static I17F15 StrictLossyFrom(I68F60 from) {
-            return FromBits(checked((int)(from.Bits / (I68F60.EpsilonRepr << 45)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static I17F15 UncheckedLossyFrom(I68F60 from) {
-            return FromBits(unchecked((int)(from.Bits / (I68F60.EpsilonRepr << 45)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        public static I17F15? CheckedLossyFrom(I68F60 from) {
-            var tmp = from.Bits / (I68F60.EpsilonRepr << 45);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I17F15(I68F60 from) {
+            return FromBits((int)(from.Bits / (I68F60.EpsilonRepr << 45)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -670,236 +538,62 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I17F15 LossyFrom(I8F120 from) {
-            return FromBits(unchecked((int)(from.Bits / (I8F120.EpsilonRepr << 105)))
-            );
+        public static explicit operator I17F15(I8F120 from) {
+            return FromBits((int)(from.Bits / (I8F120.EpsilonRepr << 105)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static I17F15 StrictFrom(U17F15 from) {
-            return FromBits(checked((int)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static I17F15 UncheckedFrom(U17F15 from) {
-            return FromBits(unchecked((int)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        public static I17F15? CheckedFrom(U17F15 from) {
-            const int shift = 0;
-            const int k = EpsilonRepr << shift;
-            const int max = MaxRepr / k;
-            if (from.Bits > (uint)max) {
-                return null;
-            }
-            return FromBits((int)from.Bits * k);
+        public static explicit operator I17F15(U17F15 from) {
+            return FromBits((int)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I17F15 LossyFrom(U2F30 from) {
-            return FromBits(unchecked((int)(from.Bits / (U2F30.EpsilonRepr << 15)))
-            );
+        public static explicit operator I17F15(U2F30 from) {
+            return FromBits((int)(from.Bits / (U2F30.EpsilonRepr << 15)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U34F30)"/>
-        /// <seealso cref="CheckedLossyFrom(U34F30)"/>
-        public static I17F15 StrictLossyFrom(U34F30 from) {
-            return FromBits(checked((int)(from.Bits / (U34F30.EpsilonRepr << 15)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U34F30)"/>
-        /// <seealso cref="CheckedLossyFrom(U34F30)"/>
-        public static I17F15 UncheckedLossyFrom(U34F30 from) {
-            return FromBits(unchecked((int)(from.Bits / (U34F30.EpsilonRepr << 15)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U34F30)"/>
-        /// <seealso cref="UncheckedLossyFrom(U34F30)"/>
-        public static I17F15? CheckedLossyFrom(U34F30 from) {
-            var tmp = from.Bits / (U34F30.EpsilonRepr << 15);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I17F15(U34F30 from) {
+            return FromBits((int)(from.Bits / (U34F30.EpsilonRepr << 15)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(U33F31)"/>
-        public static I17F15 StrictLossyFrom(U33F31 from) {
-            return FromBits(checked((int)(from.Bits / (U33F31.EpsilonRepr << 16)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(U33F31)"/>
-        public static I17F15 UncheckedLossyFrom(U33F31 from) {
-            return FromBits(unchecked((int)(from.Bits / (U33F31.EpsilonRepr << 16)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U33F31)"/>
-        /// <seealso cref="UncheckedLossyFrom(U33F31)"/>
-        public static I17F15? CheckedLossyFrom(U33F31 from) {
-            var tmp = from.Bits / (U33F31.EpsilonRepr << 16);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I17F15(U33F31 from) {
+            return FromBits((int)(from.Bits / (U33F31.EpsilonRepr << 16)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I17F15 LossyFrom(U4F60 from) {
-            return FromBits(unchecked((int)(from.Bits / (U4F60.EpsilonRepr << 45)))
-            );
+        public static explicit operator I17F15(U4F60 from) {
+            return FromBits((int)(from.Bits / (U4F60.EpsilonRepr << 45)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I17F15 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((int)(from.Bits / (U2F62.EpsilonRepr << 47)))
-            );
+        public static explicit operator I17F15(U2F62 from) {
+            return FromBits((int)(from.Bits / (U2F62.EpsilonRepr << 47)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static I17F15 StrictLossyFrom(U68F60 from) {
-            return FromBits(checked((int)(from.Bits / (U68F60.EpsilonRepr << 45)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static I17F15 UncheckedLossyFrom(U68F60 from) {
-            return FromBits(unchecked((int)(from.Bits / (U68F60.EpsilonRepr << 45)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        public static I17F15? CheckedLossyFrom(U68F60 from) {
-            var tmp = from.Bits / (U68F60.EpsilonRepr << 45);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I17F15(U68F60 from) {
+            return FromBits((int)(from.Bits / (U68F60.EpsilonRepr << 45)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -908,11 +602,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I17F15 LossyFrom(U8F120 from) {
-            return FromBits(unchecked((int)(from.Bits / (U8F120.EpsilonRepr << 105)))
-            );
+        public static explicit operator I17F15(U8F120 from) {
+            return FromBits((int)(from.Bits / (U8F120.EpsilonRepr << 105)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/I2F30.gen.cs
+++ b/Intar/I2F30.gen.cs
@@ -336,268 +336,50 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static I2F30 StrictFrom(I17F15 from) {
-            return FromBits(checked((int)from.Bits * (EpsilonRepr << 15))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static I2F30 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((int)from.Bits * (EpsilonRepr << 15))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static I2F30? CheckedFrom(I17F15 from) {
-            const int shift = 15;
-            const int k = EpsilonRepr << shift;
-            const int max = MaxRepr / k;
-            const int min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((int)from.Bits * k);
+        public static explicit operator I2F30(I17F15 from) {
+            return FromBits((int)from.Bits * (EpsilonRepr << 15));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static I2F30 StrictFrom(I34F30 from) {
-            return FromBits(checked((int)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static I2F30 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((int)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static I2F30? CheckedFrom(I34F30 from) {
-            const int shift = 0;
-            const int k = EpsilonRepr << shift;
-            const int max = MaxRepr / k;
-            const int min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((int)from.Bits * k);
+        public static explicit operator I2F30(I34F30 from) {
+            return FromBits((int)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(I33F31)"/>
-        public static I2F30 StrictLossyFrom(I33F31 from) {
-            return FromBits(checked((int)(from.Bits / (I33F31.EpsilonRepr << 1)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(I33F31)"/>
-        public static I2F30 UncheckedLossyFrom(I33F31 from) {
-            return FromBits(unchecked((int)(from.Bits / (I33F31.EpsilonRepr << 1)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I33F31)"/>
-        /// <seealso cref="UncheckedLossyFrom(I33F31)"/>
-        public static I2F30? CheckedLossyFrom(I33F31 from) {
-            var tmp = from.Bits / (I33F31.EpsilonRepr << 1);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I2F30(I33F31 from) {
+            return FromBits((int)(from.Bits / (I33F31.EpsilonRepr << 1)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I4F60)"/>
-        public static I2F30 StrictLossyFrom(I4F60 from) {
-            return FromBits(checked((int)(from.Bits / (I4F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I4F60)"/>
-        public static I2F30 UncheckedLossyFrom(I4F60 from) {
-            return FromBits(unchecked((int)(from.Bits / (I4F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I4F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I4F60)"/>
-        public static I2F30? CheckedLossyFrom(I4F60 from) {
-            var tmp = from.Bits / (I4F60.EpsilonRepr << 30);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I2F30(I4F60 from) {
+            return FromBits((int)(from.Bits / (I4F60.EpsilonRepr << 30)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I2F30 LossyFrom(I2F62 from) {
-            return FromBits(unchecked((int)(from.Bits / (I2F62.EpsilonRepr << 32)))
-            );
+        public static explicit operator I2F30(I2F62 from) {
+            return FromBits((int)(from.Bits / (I2F62.EpsilonRepr << 32)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static I2F30 StrictLossyFrom(I68F60 from) {
-            return FromBits(checked((int)(from.Bits / (I68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static I2F30 UncheckedLossyFrom(I68F60 from) {
-            return FromBits(unchecked((int)(from.Bits / (I68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        public static I2F30? CheckedLossyFrom(I68F60 from) {
-            var tmp = from.Bits / (I68F60.EpsilonRepr << 30);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I2F30(I68F60 from) {
+            return FromBits((int)(from.Bits / (I68F60.EpsilonRepr << 30)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -606,397 +388,62 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static I2F30 StrictLossyFrom(I8F120 from) {
-            return FromBits(checked((int)(from.Bits / (I8F120.EpsilonRepr << 90)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static I2F30 UncheckedLossyFrom(I8F120 from) {
-            return FromBits(unchecked((int)(from.Bits / (I8F120.EpsilonRepr << 90)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        public static I2F30? CheckedLossyFrom(I8F120 from) {
-            var tmp = from.Bits / (I8F120.EpsilonRepr << 90);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I2F30(I8F120 from) {
+            return FromBits((int)(from.Bits / (I8F120.EpsilonRepr << 90)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static I2F30 StrictFrom(U17F15 from) {
-            return FromBits(checked((int)from.Bits * (EpsilonRepr << 15))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static I2F30 UncheckedFrom(U17F15 from) {
-            return FromBits(unchecked((int)from.Bits * (EpsilonRepr << 15))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        public static I2F30? CheckedFrom(U17F15 from) {
-            const int shift = 15;
-            const int k = EpsilonRepr << shift;
-            const int max = MaxRepr / k;
-            if (from.Bits > (uint)max) {
-                return null;
-            }
-            return FromBits((int)from.Bits * k);
+        public static explicit operator I2F30(U17F15 from) {
+            return FromBits((int)from.Bits * (EpsilonRepr << 15));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U2F30)"/>
-        /// <seealso cref="CheckedFrom(U2F30)"/>
-        public static I2F30 StrictFrom(U2F30 from) {
-            return FromBits(checked((int)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U2F30)"/>
-        /// <seealso cref="CheckedFrom(U2F30)"/>
-        public static I2F30 UncheckedFrom(U2F30 from) {
-            return FromBits(unchecked((int)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U2F30)"/>
-        /// <seealso cref="UncheckedFrom(U2F30)"/>
-        public static I2F30? CheckedFrom(U2F30 from) {
-            const int shift = 0;
-            const int k = EpsilonRepr << shift;
-            const int max = MaxRepr / k;
-            if (from.Bits > (uint)max) {
-                return null;
-            }
-            return FromBits((int)from.Bits * k);
+        public static explicit operator I2F30(U2F30 from) {
+            return FromBits((int)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I2F30 StrictFrom(U34F30 from) {
-            return FromBits(checked((int)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I2F30 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((int)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static I2F30? CheckedFrom(U34F30 from) {
-            const int shift = 0;
-            const int k = EpsilonRepr << shift;
-            const int max = MaxRepr / k;
-            if (from.Bits > (uint)max) {
-                return null;
-            }
-            return FromBits((int)from.Bits * k);
+        public static explicit operator I2F30(U34F30 from) {
+            return FromBits((int)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(U33F31)"/>
-        public static I2F30 StrictLossyFrom(U33F31 from) {
-            return FromBits(checked((int)(from.Bits / (U33F31.EpsilonRepr << 1)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(U33F31)"/>
-        public static I2F30 UncheckedLossyFrom(U33F31 from) {
-            return FromBits(unchecked((int)(from.Bits / (U33F31.EpsilonRepr << 1)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U33F31)"/>
-        /// <seealso cref="UncheckedLossyFrom(U33F31)"/>
-        public static I2F30? CheckedLossyFrom(U33F31 from) {
-            var tmp = from.Bits / (U33F31.EpsilonRepr << 1);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I2F30(U33F31 from) {
+            return FromBits((int)(from.Bits / (U33F31.EpsilonRepr << 1)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U4F60)"/>
-        public static I2F30 StrictLossyFrom(U4F60 from) {
-            return FromBits(checked((int)(from.Bits / (U4F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U4F60)"/>
-        public static I2F30 UncheckedLossyFrom(U4F60 from) {
-            return FromBits(unchecked((int)(from.Bits / (U4F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U4F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(U4F60)"/>
-        public static I2F30? CheckedLossyFrom(U4F60 from) {
-            var tmp = from.Bits / (U4F60.EpsilonRepr << 30);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I2F30(U4F60 from) {
+            return FromBits((int)(from.Bits / (U4F60.EpsilonRepr << 30)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(U2F62)"/>
-        public static I2F30 StrictLossyFrom(U2F62 from) {
-            return FromBits(checked((int)(from.Bits / (U2F62.EpsilonRepr << 32)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(U2F62)"/>
-        public static I2F30 UncheckedLossyFrom(U2F62 from) {
-            return FromBits(unchecked((int)(from.Bits / (U2F62.EpsilonRepr << 32)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U2F62)"/>
-        /// <seealso cref="UncheckedLossyFrom(U2F62)"/>
-        public static I2F30? CheckedLossyFrom(U2F62 from) {
-            var tmp = from.Bits / (U2F62.EpsilonRepr << 32);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I2F30(U2F62 from) {
+            return FromBits((int)(from.Bits / (U2F62.EpsilonRepr << 32)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static I2F30 StrictLossyFrom(U68F60 from) {
-            return FromBits(checked((int)(from.Bits / (U68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static I2F30 UncheckedLossyFrom(U68F60 from) {
-            return FromBits(unchecked((int)(from.Bits / (U68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        public static I2F30? CheckedLossyFrom(U68F60 from) {
-            var tmp = from.Bits / (U68F60.EpsilonRepr << 30);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I2F30(U68F60 from) {
+            return FromBits((int)(from.Bits / (U68F60.EpsilonRepr << 30)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -1005,50 +452,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static I2F30 StrictLossyFrom(U8F120 from) {
-            return FromBits(checked((int)(from.Bits / (U8F120.EpsilonRepr << 90)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static I2F30 UncheckedLossyFrom(U8F120 from) {
-            return FromBits(unchecked((int)(from.Bits / (U8F120.EpsilonRepr << 90)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        public static I2F30? CheckedLossyFrom(U8F120 from) {
-            var tmp = from.Bits / (U8F120.EpsilonRepr << 90);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((int)tmp);
+        public static explicit operator I2F30(U8F120 from) {
+            return FromBits((int)(from.Bits / (U8F120.EpsilonRepr << 90)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/I2F62.gen.cs
+++ b/Intar/I2F62.gen.cs
@@ -351,277 +351,50 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static I2F62 StrictFrom(I17F15 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 47))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static I2F62 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 47))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static I2F62? CheckedFrom(I17F15 from) {
-            const int shift = 47;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            const long min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(I17F15 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 47));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I2F62 From(I2F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 32))
-            );
+        public static explicit operator I2F62(I2F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 32));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static I2F62 StrictFrom(I34F30 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static I2F62 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static I2F62? CheckedFrom(I34F30 from) {
-            const int shift = 32;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            const long min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(I34F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 32));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static I2F62 StrictFrom(I33F31 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 31))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static I2F62 UncheckedFrom(I33F31 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 31))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        public static I2F62? CheckedFrom(I33F31 from) {
-            const int shift = 31;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            const long min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(I33F31 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 31));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I4F60)"/>
-        /// <seealso cref="CheckedFrom(I4F60)"/>
-        public static I2F62 StrictFrom(I4F60 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I4F60)"/>
-        /// <seealso cref="CheckedFrom(I4F60)"/>
-        public static I2F62 UncheckedFrom(I4F60 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I4F60)"/>
-        /// <seealso cref="UncheckedFrom(I4F60)"/>
-        public static I2F62? CheckedFrom(I4F60 from) {
-            const int shift = 2;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            const long min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(I4F60 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 2));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static I2F62 StrictFrom(I68F60 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static I2F62 UncheckedFrom(I68F60 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        public static I2F62? CheckedFrom(I68F60 from) {
-            const int shift = 2;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            const long min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(I68F60 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 2));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -630,405 +403,62 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static I2F62 StrictLossyFrom(I8F120 from) {
-            return FromBits(checked((long)(from.Bits / (I8F120.EpsilonRepr << 58)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static I2F62 UncheckedLossyFrom(I8F120 from) {
-            return FromBits(unchecked((long)(from.Bits / (I8F120.EpsilonRepr << 58)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        public static I2F62? CheckedLossyFrom(I8F120 from) {
-            var tmp = from.Bits / (I8F120.EpsilonRepr << 58);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((long)tmp);
+        public static explicit operator I2F62(I8F120 from) {
+            return FromBits((long)(from.Bits / (I8F120.EpsilonRepr << 58)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static I2F62 StrictFrom(U17F15 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 47))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static I2F62 UncheckedFrom(U17F15 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 47))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        public static I2F62? CheckedFrom(U17F15 from) {
-            const int shift = 47;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(U17F15 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 47));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U2F30)"/>
-        /// <seealso cref="CheckedFrom(U2F30)"/>
-        public static I2F62 StrictFrom(U2F30 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U2F30)"/>
-        /// <seealso cref="CheckedFrom(U2F30)"/>
-        public static I2F62 UncheckedFrom(U2F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U2F30)"/>
-        /// <seealso cref="UncheckedFrom(U2F30)"/>
-        public static I2F62? CheckedFrom(U2F30 from) {
-            const int shift = 32;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(U2F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 32));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I2F62 StrictFrom(U34F30 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I2F62 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static I2F62? CheckedFrom(U34F30 from) {
-            const int shift = 32;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(U34F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 32));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static I2F62 StrictFrom(U33F31 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 31))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static I2F62 UncheckedFrom(U33F31 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 31))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        public static I2F62? CheckedFrom(U33F31 from) {
-            const int shift = 31;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(U33F31 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 31));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U4F60)"/>
-        /// <seealso cref="CheckedFrom(U4F60)"/>
-        public static I2F62 StrictFrom(U4F60 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U4F60)"/>
-        /// <seealso cref="CheckedFrom(U4F60)"/>
-        public static I2F62 UncheckedFrom(U4F60 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U4F60)"/>
-        /// <seealso cref="UncheckedFrom(U4F60)"/>
-        public static I2F62? CheckedFrom(U4F60 from) {
-            const int shift = 2;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(U4F60 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 2));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U2F62)"/>
-        /// <seealso cref="CheckedFrom(U2F62)"/>
-        public static I2F62 StrictFrom(U2F62 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U2F62)"/>
-        /// <seealso cref="CheckedFrom(U2F62)"/>
-        public static I2F62 UncheckedFrom(U2F62 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U2F62)"/>
-        /// <seealso cref="UncheckedFrom(U2F62)"/>
-        public static I2F62? CheckedFrom(U2F62 from) {
-            const int shift = 0;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(U2F62 from) {
+            return FromBits((long)from.Bits);
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static I2F62 StrictFrom(U68F60 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static I2F62 UncheckedFrom(U68F60 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        public static I2F62? CheckedFrom(U68F60 from) {
-            const int shift = 2;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I2F62(U68F60 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 2));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -1037,50 +467,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static I2F62 StrictLossyFrom(U8F120 from) {
-            return FromBits(checked((long)(from.Bits / (U8F120.EpsilonRepr << 58)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static I2F62 UncheckedLossyFrom(U8F120 from) {
-            return FromBits(unchecked((long)(from.Bits / (U8F120.EpsilonRepr << 58)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        public static I2F62? CheckedLossyFrom(U8F120 from) {
-            var tmp = from.Bits / (U8F120.EpsilonRepr << 58);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((long)tmp);
+        public static explicit operator I2F62(U8F120 from) {
+            return FromBits((long)(from.Bits / (U8F120.EpsilonRepr << 58)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/I33F31.gen.cs
+++ b/Intar/I33F31.gen.cs
@@ -578,145 +578,50 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I33F31 From(I17F15 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 16))
-            );
+        public static explicit operator I33F31(I17F15 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 16));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I33F31 From(I2F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 1))
-            );
+        public static explicit operator I33F31(I2F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 1));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static I33F31 StrictFrom(I34F30 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 1))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static I33F31 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 1))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static I33F31? CheckedFrom(I34F30 from) {
-            const int shift = 1;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            const long min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I33F31(I34F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 1));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I33F31 LossyFrom(I4F60 from) {
-            return FromBits(unchecked((long)(from.Bits / (I4F60.EpsilonRepr << 29)))
-            );
+        public static explicit operator I33F31(I4F60 from) {
+            return FromBits((long)(from.Bits / (I4F60.EpsilonRepr << 29)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I33F31 LossyFrom(I2F62 from) {
-            return FromBits(unchecked((long)(from.Bits / (I2F62.EpsilonRepr << 31)))
-            );
+        public static explicit operator I33F31(I2F62 from) {
+            return FromBits((long)(from.Bits / (I2F62.EpsilonRepr << 31)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static I33F31 StrictLossyFrom(I68F60 from) {
-            return FromBits(checked((long)(from.Bits / (I68F60.EpsilonRepr << 29)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static I33F31 UncheckedLossyFrom(I68F60 from) {
-            return FromBits(unchecked((long)(from.Bits / (I68F60.EpsilonRepr << 29)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        public static I33F31? CheckedLossyFrom(I68F60 from) {
-            var tmp = from.Bits / (I68F60.EpsilonRepr << 29);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((long)tmp);
+        public static explicit operator I33F31(I68F60 from) {
+            return FromBits((long)(from.Bits / (I68F60.EpsilonRepr << 29)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -725,199 +630,62 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I33F31 LossyFrom(I8F120 from) {
-            return FromBits(unchecked((long)(from.Bits / (I8F120.EpsilonRepr << 89)))
-            );
+        public static explicit operator I33F31(I8F120 from) {
+            return FromBits((long)(from.Bits / (I8F120.EpsilonRepr << 89)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I33F31 From(U17F15 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 16))
-            );
+        public static explicit operator I33F31(U17F15 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 16));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I33F31 From(U2F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 1))
-            );
+        public static explicit operator I33F31(U2F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 1));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I33F31 StrictFrom(U34F30 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 1))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I33F31 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 1))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static I33F31? CheckedFrom(U34F30 from) {
-            const int shift = 1;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I33F31(U34F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 1));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static I33F31 StrictFrom(U33F31 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static I33F31 UncheckedFrom(U33F31 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        public static I33F31? CheckedFrom(U33F31 from) {
-            const int shift = 0;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I33F31(U33F31 from) {
+            return FromBits((long)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I33F31 LossyFrom(U4F60 from) {
-            return FromBits(unchecked((long)(from.Bits / (U4F60.EpsilonRepr << 29)))
-            );
+        public static explicit operator I33F31(U4F60 from) {
+            return FromBits((long)(from.Bits / (U4F60.EpsilonRepr << 29)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I33F31 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((long)(from.Bits / (U2F62.EpsilonRepr << 31)))
-            );
+        public static explicit operator I33F31(U2F62 from) {
+            return FromBits((long)(from.Bits / (U2F62.EpsilonRepr << 31)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static I33F31 StrictLossyFrom(U68F60 from) {
-            return FromBits(checked((long)(from.Bits / (U68F60.EpsilonRepr << 29)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static I33F31 UncheckedLossyFrom(U68F60 from) {
-            return FromBits(unchecked((long)(from.Bits / (U68F60.EpsilonRepr << 29)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        public static I33F31? CheckedLossyFrom(U68F60 from) {
-            var tmp = from.Bits / (U68F60.EpsilonRepr << 29);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((long)tmp);
+        public static explicit operator I33F31(U68F60 from) {
+            return FromBits((long)(from.Bits / (U68F60.EpsilonRepr << 29)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -926,11 +694,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I33F31 LossyFrom(U8F120 from) {
-            return FromBits(unchecked((long)(from.Bits / (U8F120.EpsilonRepr << 89)))
-            );
+        public static explicit operator I33F31(U8F120 from) {
+            return FromBits((long)(from.Bits / (U8F120.EpsilonRepr << 89)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/I34F30.gen.cs
+++ b/Intar/I34F30.gen.cs
@@ -350,102 +350,50 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 From(I17F15 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 15))
-            );
+        public static explicit operator I34F30(I17F15 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 15));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 From(I2F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 0))
-            );
+        public static explicit operator I34F30(I2F30 from) {
+            return FromBits((long)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 LossyFrom(I33F31 from) {
-            return FromBits(unchecked((long)(from.Bits / (I33F31.EpsilonRepr << 1)))
-            );
+        public static explicit operator I34F30(I33F31 from) {
+            return FromBits((long)(from.Bits / (I33F31.EpsilonRepr << 1)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 LossyFrom(I4F60 from) {
-            return FromBits(unchecked((long)(from.Bits / (I4F60.EpsilonRepr << 30)))
-            );
+        public static explicit operator I34F30(I4F60 from) {
+            return FromBits((long)(from.Bits / (I4F60.EpsilonRepr << 30)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 LossyFrom(I2F62 from) {
-            return FromBits(unchecked((long)(from.Bits / (I2F62.EpsilonRepr << 32)))
-            );
+        public static explicit operator I34F30(I2F62 from) {
+            return FromBits((long)(from.Bits / (I2F62.EpsilonRepr << 32)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static I34F30 StrictLossyFrom(I68F60 from) {
-            return FromBits(checked((long)(from.Bits / (I68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static I34F30 UncheckedLossyFrom(I68F60 from) {
-            return FromBits(unchecked((long)(from.Bits / (I68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        public static I34F30? CheckedLossyFrom(I68F60 from) {
-            var tmp = from.Bits / (I68F60.EpsilonRepr << 30);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((long)tmp);
+        public static explicit operator I34F30(I68F60 from) {
+            return FromBits((long)(from.Bits / (I68F60.EpsilonRepr << 30)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -454,158 +402,62 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 LossyFrom(I8F120 from) {
-            return FromBits(unchecked((long)(from.Bits / (I8F120.EpsilonRepr << 90)))
-            );
+        public static explicit operator I34F30(I8F120 from) {
+            return FromBits((long)(from.Bits / (I8F120.EpsilonRepr << 90)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 From(U17F15 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 15))
-            );
+        public static explicit operator I34F30(U17F15 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 15));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 From(U2F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 0))
-            );
+        public static explicit operator I34F30(U2F30 from) {
+            return FromBits((long)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I34F30 StrictFrom(U34F30 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I34F30 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static I34F30? CheckedFrom(U34F30 from) {
-            const int shift = 0;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I34F30(U34F30 from) {
+            return FromBits((long)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 LossyFrom(U33F31 from) {
-            return FromBits(unchecked((long)(from.Bits / (U33F31.EpsilonRepr << 1)))
-            );
+        public static explicit operator I34F30(U33F31 from) {
+            return FromBits((long)(from.Bits / (U33F31.EpsilonRepr << 1)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 LossyFrom(U4F60 from) {
-            return FromBits(unchecked((long)(from.Bits / (U4F60.EpsilonRepr << 30)))
-            );
+        public static explicit operator I34F30(U4F60 from) {
+            return FromBits((long)(from.Bits / (U4F60.EpsilonRepr << 30)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((long)(from.Bits / (U2F62.EpsilonRepr << 32)))
-            );
+        public static explicit operator I34F30(U2F62 from) {
+            return FromBits((long)(from.Bits / (U2F62.EpsilonRepr << 32)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static I34F30 StrictLossyFrom(U68F60 from) {
-            return FromBits(checked((long)(from.Bits / (U68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static I34F30 UncheckedLossyFrom(U68F60 from) {
-            return FromBits(unchecked((long)(from.Bits / (U68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        public static I34F30? CheckedLossyFrom(U68F60 from) {
-            var tmp = from.Bits / (U68F60.EpsilonRepr << 30);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((long)tmp);
+        public static explicit operator I34F30(U68F60 from) {
+            return FromBits((long)(from.Bits / (U68F60.EpsilonRepr << 30)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -614,11 +466,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I34F30 LossyFrom(U8F120 from) {
-            return FromBits(unchecked((long)(from.Bits / (U8F120.EpsilonRepr << 90)))
-            );
+        public static explicit operator I34F30(U8F120 from) {
+            return FromBits((long)(from.Bits / (U8F120.EpsilonRepr << 90)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/I4F60.gen.cs
+++ b/Intar/I4F60.gen.cs
@@ -350,234 +350,50 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static I4F60 StrictFrom(I17F15 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 45))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static I4F60 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 45))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static I4F60? CheckedFrom(I17F15 from) {
-            const int shift = 45;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            const long min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I4F60(I17F15 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 45));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I4F60 From(I2F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 30))
-            );
+        public static explicit operator I4F60(I2F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static I4F60 StrictFrom(I34F30 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static I4F60 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static I4F60? CheckedFrom(I34F30 from) {
-            const int shift = 30;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            const long min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I4F60(I34F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static I4F60 StrictFrom(I33F31 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 29))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static I4F60 UncheckedFrom(I33F31 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 29))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        public static I4F60? CheckedFrom(I33F31 from) {
-            const int shift = 29;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            const long min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I4F60(I33F31 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 29));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I4F60 LossyFrom(I2F62 from) {
-            return FromBits(unchecked((long)(from.Bits / (I2F62.EpsilonRepr << 2)))
-            );
+        public static explicit operator I4F60(I2F62 from) {
+            return FromBits((long)(from.Bits / (I2F62.EpsilonRepr << 2)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static I4F60 StrictFrom(I68F60 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static I4F60 UncheckedFrom(I68F60 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        public static I4F60? CheckedFrom(I68F60 from) {
-            const int shift = 0;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            const long min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I4F60(I68F60 from) {
+            return FromBits((long)from.Bits);
         }
 
 #endif // NET7_0_OR_GREATER
@@ -586,323 +402,62 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static I4F60 StrictLossyFrom(I8F120 from) {
-            return FromBits(checked((long)(from.Bits / (I8F120.EpsilonRepr << 60)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static I4F60 UncheckedLossyFrom(I8F120 from) {
-            return FromBits(unchecked((long)(from.Bits / (I8F120.EpsilonRepr << 60)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        public static I4F60? CheckedLossyFrom(I8F120 from) {
-            var tmp = from.Bits / (I8F120.EpsilonRepr << 60);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((long)tmp);
+        public static explicit operator I4F60(I8F120 from) {
+            return FromBits((long)(from.Bits / (I8F120.EpsilonRepr << 60)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static I4F60 StrictFrom(U17F15 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 45))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static I4F60 UncheckedFrom(U17F15 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 45))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        public static I4F60? CheckedFrom(U17F15 from) {
-            const int shift = 45;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I4F60(U17F15 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 45));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I4F60 From(U2F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 30))
-            );
+        public static explicit operator I4F60(U2F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I4F60 StrictFrom(U34F30 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I4F60 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static I4F60? CheckedFrom(U34F30 from) {
-            const int shift = 30;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I4F60(U34F30 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static I4F60 StrictFrom(U33F31 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 29))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static I4F60 UncheckedFrom(U33F31 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 29))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        public static I4F60? CheckedFrom(U33F31 from) {
-            const int shift = 29;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I4F60(U33F31 from) {
+            return FromBits((long)from.Bits * (EpsilonRepr << 29));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U4F60)"/>
-        /// <seealso cref="CheckedFrom(U4F60)"/>
-        public static I4F60 StrictFrom(U4F60 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U4F60)"/>
-        /// <seealso cref="CheckedFrom(U4F60)"/>
-        public static I4F60 UncheckedFrom(U4F60 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U4F60)"/>
-        /// <seealso cref="UncheckedFrom(U4F60)"/>
-        public static I4F60? CheckedFrom(U4F60 from) {
-            const int shift = 0;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I4F60(U4F60 from) {
+            return FromBits((long)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I4F60 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((long)(from.Bits / (U2F62.EpsilonRepr << 2)))
-            );
+        public static explicit operator I4F60(U2F62 from) {
+            return FromBits((long)(from.Bits / (U2F62.EpsilonRepr << 2)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static I4F60 StrictFrom(U68F60 from) {
-            return FromBits(checked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static I4F60 UncheckedFrom(U68F60 from) {
-            return FromBits(unchecked((long)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        public static I4F60? CheckedFrom(U68F60 from) {
-            const int shift = 0;
-            const long k = EpsilonRepr << shift;
-            const long max = MaxRepr / k;
-            if (from.Bits > (ulong)max) {
-                return null;
-            }
-            return FromBits((long)from.Bits * k);
+        public static explicit operator I4F60(U68F60 from) {
+            return FromBits((long)from.Bits);
         }
 
 #endif // NET7_0_OR_GREATER
@@ -911,50 +466,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static I4F60 StrictLossyFrom(U8F120 from) {
-            return FromBits(checked((long)(from.Bits / (U8F120.EpsilonRepr << 60)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static I4F60 UncheckedLossyFrom(U8F120 from) {
-            return FromBits(unchecked((long)(from.Bits / (U8F120.EpsilonRepr << 60)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        public static I4F60? CheckedLossyFrom(U8F120 from) {
-            var tmp = from.Bits / (U8F120.EpsilonRepr << 60);
-            if (tmp > MaxReprUnsigned) {
-                return null;
-            }
-            return FromBits((long)tmp);
+        public static explicit operator I4F60(U8F120 from) {
+            return FromBits((long)(from.Bits / (U8F120.EpsilonRepr << 60)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/I68F60.gen.cs
+++ b/Intar/I68F60.gen.cs
@@ -271,179 +271,110 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 From(I17F15 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 45))
-            );
+        public static explicit operator I68F60(I17F15 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 45));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 From(I2F30 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 30))
-            );
+        public static explicit operator I68F60(I2F30 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 From(I34F30 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 30))
-            );
+        public static explicit operator I68F60(I34F30 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 From(I33F31 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 29))
-            );
+        public static explicit operator I68F60(I33F31 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 29));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 From(I4F60 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 0))
-            );
+        public static explicit operator I68F60(I4F60 from) {
+            return FromBits((Int128)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 LossyFrom(I2F62 from) {
-            return FromBits(unchecked((Int128)(from.Bits / (I2F62.EpsilonRepr << 2)))
-            );
+        public static explicit operator I68F60(I2F62 from) {
+            return FromBits((Int128)(from.Bits / (I2F62.EpsilonRepr << 2)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 LossyFrom(I8F120 from) {
-            return FromBits(unchecked((Int128)(from.Bits / (I8F120.EpsilonRepr << 60)))
-            );
+        public static explicit operator I68F60(I8F120 from) {
+            return FromBits((Int128)(from.Bits / (I8F120.EpsilonRepr << 60)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 From(U17F15 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 45))
-            );
+        public static explicit operator I68F60(U17F15 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 45));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 From(U2F30 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 30))
-            );
+        public static explicit operator I68F60(U2F30 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 From(U34F30 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 30))
-            );
+        public static explicit operator I68F60(U34F30 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 From(U33F31 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 29))
-            );
+        public static explicit operator I68F60(U33F31 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 29));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 From(U4F60 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 0))
-            );
+        public static explicit operator I68F60(U4F60 from) {
+            return FromBits((Int128)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((Int128)(from.Bits / (U2F62.EpsilonRepr << 2)))
-            );
+        public static explicit operator I68F60(U2F62 from) {
+            return FromBits((Int128)(from.Bits / (U2F62.EpsilonRepr << 2)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static I68F60 StrictFrom(U68F60 from) {
-            return FromBits(checked((Int128)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static I68F60 UncheckedFrom(U68F60 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        public static I68F60? CheckedFrom(U68F60 from) {
-            const int shift = 0;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits > (UInt128)max) {
-                return null;
-            }
-            return FromBits((Int128)from.Bits * k);
+        public static explicit operator I68F60(U68F60 from) {
+            return FromBits((Int128)from.Bits);
         }
 
 #endif // NET7_0_OR_GREATER
@@ -452,11 +383,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I68F60 LossyFrom(U8F120 from) {
-            return FromBits(unchecked((Int128)(from.Bits / (U8F120.EpsilonRepr << 60)))
-            );
+        public static explicit operator I68F60(U8F120 from) {
+            return FromBits((Int128)(from.Bits / (U8F120.EpsilonRepr << 60)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/I8F120.gen.cs
+++ b/Intar/I8F120.gen.cs
@@ -271,474 +271,110 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static I8F120 StrictFrom(I17F15 from) {
-            return FromBits(checked((Int128)from.Bits * (EpsilonRepr << 105))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static I8F120 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 105))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static I8F120? CheckedFrom(I17F15 from) {
-            const int shift = 105;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            var min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((Int128)from.Bits * k);
+        public static explicit operator I8F120(I17F15 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 105));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I8F120 From(I2F30 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 90))
-            );
+        public static explicit operator I8F120(I2F30 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 90));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static I8F120 StrictFrom(I34F30 from) {
-            return FromBits(checked((Int128)from.Bits * (EpsilonRepr << 90))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static I8F120 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 90))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static I8F120? CheckedFrom(I34F30 from) {
-            const int shift = 90;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            var min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((Int128)from.Bits * k);
+        public static explicit operator I8F120(I34F30 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 90));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static I8F120 StrictFrom(I33F31 from) {
-            return FromBits(checked((Int128)from.Bits * (EpsilonRepr << 89))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static I8F120 UncheckedFrom(I33F31 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 89))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        public static I8F120? CheckedFrom(I33F31 from) {
-            const int shift = 89;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            var min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((Int128)from.Bits * k);
+        public static explicit operator I8F120(I33F31 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 89));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I8F120 From(I4F60 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 60))
-            );
+        public static explicit operator I8F120(I4F60 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 60));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I8F120 From(I2F62 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 58))
-            );
+        public static explicit operator I8F120(I2F62 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 58));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static I8F120 StrictFrom(I68F60 from) {
-            return FromBits(checked((Int128)from.Bits * (EpsilonRepr << 60))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static I8F120 UncheckedFrom(I68F60 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 60))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        public static I8F120? CheckedFrom(I68F60 from) {
-            const int shift = 60;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            var min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((Int128)from.Bits * k);
+        public static explicit operator I8F120(I68F60 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 60));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static I8F120 StrictFrom(U17F15 from) {
-            return FromBits(checked((Int128)from.Bits * (EpsilonRepr << 105))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static I8F120 UncheckedFrom(U17F15 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 105))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        public static I8F120? CheckedFrom(U17F15 from) {
-            const int shift = 105;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits > (UInt128)max) {
-                return null;
-            }
-            return FromBits((Int128)from.Bits * k);
+        public static explicit operator I8F120(U17F15 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 105));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I8F120 From(U2F30 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 90))
-            );
+        public static explicit operator I8F120(U2F30 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 90));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I8F120 StrictFrom(U34F30 from) {
-            return FromBits(checked((Int128)from.Bits * (EpsilonRepr << 90))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static I8F120 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 90))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static I8F120? CheckedFrom(U34F30 from) {
-            const int shift = 90;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits > (UInt128)max) {
-                return null;
-            }
-            return FromBits((Int128)from.Bits * k);
+        public static explicit operator I8F120(U34F30 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 90));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static I8F120 StrictFrom(U33F31 from) {
-            return FromBits(checked((Int128)from.Bits * (EpsilonRepr << 89))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static I8F120 UncheckedFrom(U33F31 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 89))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        public static I8F120? CheckedFrom(U33F31 from) {
-            const int shift = 89;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits > (UInt128)max) {
-                return null;
-            }
-            return FromBits((Int128)from.Bits * k);
+        public static explicit operator I8F120(U33F31 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 89));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I8F120 From(U4F60 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 60))
-            );
+        public static explicit operator I8F120(U4F60 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 60));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static I8F120 From(U2F62 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 58))
-            );
+        public static explicit operator I8F120(U2F62 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 58));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static I8F120 StrictFrom(U68F60 from) {
-            return FromBits(checked((Int128)from.Bits * (EpsilonRepr << 60))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static I8F120 UncheckedFrom(U68F60 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 60))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        public static I8F120? CheckedFrom(U68F60 from) {
-            const int shift = 60;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits > (UInt128)max) {
-                return null;
-            }
-            return FromBits((Int128)from.Bits * k);
+        public static explicit operator I8F120(U68F60 from) {
+            return FromBits((Int128)from.Bits * (EpsilonRepr << 60));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -747,52 +383,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U8F120)"/>
-        /// <seealso cref="CheckedFrom(U8F120)"/>
-        public static I8F120 StrictFrom(U8F120 from) {
-            return FromBits(checked((Int128)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U8F120)"/>
-        /// <seealso cref="CheckedFrom(U8F120)"/>
-        public static I8F120 UncheckedFrom(U8F120 from) {
-            return FromBits(unchecked((Int128)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U8F120)"/>
-        /// <seealso cref="UncheckedFrom(U8F120)"/>
-        public static I8F120? CheckedFrom(U8F120 from) {
-            const int shift = 0;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits > (UInt128)max) {
-                return null;
-            }
-            return FromBits((Int128)from.Bits * k);
+        public static explicit operator I8F120(U8F120 from) {
+            return FromBits((Int128)from.Bits);
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/Matrix3x3I17F15.gen.cs
+++ b/Intar/Matrix3x3I17F15.gen.cs
@@ -142,19 +142,19 @@ namespace Intar {
         public static Matrix3x3I17F15 operator *(Matrix3x3I17F15 left, Matrix3x3I17F15 right) {
             return new Matrix3x3I17F15(
                 new Vector3I17F15(
-                    I17F15.UncheckedLossyFrom(left.R0.Dot(right.C0)),
-                    I17F15.UncheckedLossyFrom(left.R1.Dot(right.C0)),
-                    I17F15.UncheckedLossyFrom(left.R2.Dot(right.C0))
+                    (I17F15)left.R0.Dot(right.C0),
+                    (I17F15)left.R1.Dot(right.C0),
+                    (I17F15)left.R2.Dot(right.C0)
                 ),
                 new Vector3I17F15(
-                    I17F15.UncheckedLossyFrom(left.R0.Dot(right.C1)),
-                    I17F15.UncheckedLossyFrom(left.R1.Dot(right.C1)),
-                    I17F15.UncheckedLossyFrom(left.R2.Dot(right.C1))
+                    (I17F15)left.R0.Dot(right.C1),
+                    (I17F15)left.R1.Dot(right.C1),
+                    (I17F15)left.R2.Dot(right.C1)
                 ),
                 new Vector3I17F15(
-                    I17F15.UncheckedLossyFrom(left.R0.Dot(right.C2)),
-                    I17F15.UncheckedLossyFrom(left.R1.Dot(right.C2)),
-                    I17F15.UncheckedLossyFrom(left.R2.Dot(right.C2))
+                    (I17F15)left.R0.Dot(right.C2),
+                    (I17F15)left.R1.Dot(right.C2),
+                    (I17F15)left.R2.Dot(right.C2)
                 )
             );
         }

--- a/Intar/Matrix3x3I2F30.gen.cs
+++ b/Intar/Matrix3x3I2F30.gen.cs
@@ -142,19 +142,19 @@ namespace Intar {
         public static Matrix3x3I2F30 operator *(Matrix3x3I2F30 left, Matrix3x3I2F30 right) {
             return new Matrix3x3I2F30(
                 new Vector3I2F30(
-                    I2F30.UncheckedLossyFrom(left.R0.Dot(right.C0)),
-                    I2F30.UncheckedLossyFrom(left.R1.Dot(right.C0)),
-                    I2F30.UncheckedLossyFrom(left.R2.Dot(right.C0))
+                    (I2F30)left.R0.Dot(right.C0),
+                    (I2F30)left.R1.Dot(right.C0),
+                    (I2F30)left.R2.Dot(right.C0)
                 ),
                 new Vector3I2F30(
-                    I2F30.UncheckedLossyFrom(left.R0.Dot(right.C1)),
-                    I2F30.UncheckedLossyFrom(left.R1.Dot(right.C1)),
-                    I2F30.UncheckedLossyFrom(left.R2.Dot(right.C1))
+                    (I2F30)left.R0.Dot(right.C1),
+                    (I2F30)left.R1.Dot(right.C1),
+                    (I2F30)left.R2.Dot(right.C1)
                 ),
                 new Vector3I2F30(
-                    I2F30.UncheckedLossyFrom(left.R0.Dot(right.C2)),
-                    I2F30.UncheckedLossyFrom(left.R1.Dot(right.C2)),
-                    I2F30.UncheckedLossyFrom(left.R2.Dot(right.C2))
+                    (I2F30)left.R0.Dot(right.C2),
+                    (I2F30)left.R1.Dot(right.C2),
+                    (I2F30)left.R2.Dot(right.C2)
                 )
             );
         }

--- a/Intar/QuaternionI2F30.gen.cs
+++ b/Intar/QuaternionI2F30.gen.cs
@@ -269,7 +269,7 @@ namespace Intar {
 
                 // ドット積の Arccos を計算する.
                 // その後, 後の計算のために小数部の精度を 15 ビットにする.
-                var angle = I17F15.LossyFrom(I33F31.AcosP3((long)d.Bits));
+                var angle = (I17F15)I33F31.AcosP3((long)d.Bits);
 
                 // 閾値が 0.0005 の場合 invSin の最大値は
                 // (1 - (1-0.0005)^2)^(-0.5)=31.6267301900746 となる.

--- a/Intar/U17F15.gen.cs
+++ b/Intar/U17F15.gen.cs
@@ -290,360 +290,57 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U17F15 StrictFrom(I17F15 from) {
-            return FromBits(checked((uint)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U17F15 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((uint)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static U17F15? CheckedFrom(I17F15 from) {
-            const int shift = 0;
-            const uint k = EpsilonRepr << shift;
-            const uint max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((uint)from.Bits * k);
+        public static explicit operator U17F15(I17F15 from) {
+            return FromBits((uint)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I2F30)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F30)"/>
-        public static U17F15 StrictLossyFrom(I2F30 from) {
-            return FromBits(checked((uint)(from.Bits / (I2F30.EpsilonRepr << 15)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F30)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F30)"/>
-        public static U17F15 UncheckedLossyFrom(I2F30 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I2F30.EpsilonRepr << 15)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F30)"/>
-        /// <seealso cref="UncheckedLossyFrom(I2F30)"/>
-        public static U17F15? CheckedLossyFrom(I2F30 from) {
-            var tmp = from.Bits / (I2F30.EpsilonRepr << 15);
-            if (tmp < 0) {
-                return null;
-            } else if ((uint)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U17F15(I2F30 from) {
+            return FromBits((uint)(from.Bits / (I2F30.EpsilonRepr << 15)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I34F30)"/>
-        /// <seealso cref="CheckedLossyFrom(I34F30)"/>
-        public static U17F15 StrictLossyFrom(I34F30 from) {
-            return FromBits(checked((uint)(from.Bits / (I34F30.EpsilonRepr << 15)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I34F30)"/>
-        /// <seealso cref="CheckedLossyFrom(I34F30)"/>
-        public static U17F15 UncheckedLossyFrom(I34F30 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I34F30.EpsilonRepr << 15)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I34F30)"/>
-        /// <seealso cref="UncheckedLossyFrom(I34F30)"/>
-        public static U17F15? CheckedLossyFrom(I34F30 from) {
-            var tmp = from.Bits / (I34F30.EpsilonRepr << 15);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U17F15(I34F30 from) {
+            return FromBits((uint)(from.Bits / (I34F30.EpsilonRepr << 15)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(I33F31)"/>
-        public static U17F15 StrictLossyFrom(I33F31 from) {
-            return FromBits(checked((uint)(from.Bits / (I33F31.EpsilonRepr << 16)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(I33F31)"/>
-        public static U17F15 UncheckedLossyFrom(I33F31 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I33F31.EpsilonRepr << 16)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I33F31)"/>
-        /// <seealso cref="UncheckedLossyFrom(I33F31)"/>
-        public static U17F15? CheckedLossyFrom(I33F31 from) {
-            var tmp = from.Bits / (I33F31.EpsilonRepr << 16);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U17F15(I33F31 from) {
+            return FromBits((uint)(from.Bits / (I33F31.EpsilonRepr << 16)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I4F60)"/>
-        public static U17F15 StrictLossyFrom(I4F60 from) {
-            return FromBits(checked((uint)(from.Bits / (I4F60.EpsilonRepr << 45)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I4F60)"/>
-        public static U17F15 UncheckedLossyFrom(I4F60 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I4F60.EpsilonRepr << 45)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I4F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I4F60)"/>
-        public static U17F15? CheckedLossyFrom(I4F60 from) {
-            var tmp = from.Bits / (I4F60.EpsilonRepr << 45);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U17F15(I4F60 from) {
+            return FromBits((uint)(from.Bits / (I4F60.EpsilonRepr << 45)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U17F15 StrictLossyFrom(I2F62 from) {
-            return FromBits(checked((uint)(from.Bits / (I2F62.EpsilonRepr << 47)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U17F15 UncheckedLossyFrom(I2F62 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I2F62.EpsilonRepr << 47)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        public static U17F15? CheckedLossyFrom(I2F62 from) {
-            var tmp = from.Bits / (I2F62.EpsilonRepr << 47);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U17F15(I2F62 from) {
+            return FromBits((uint)(from.Bits / (I2F62.EpsilonRepr << 47)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static U17F15 StrictLossyFrom(I68F60 from) {
-            return FromBits(checked((uint)(from.Bits / (I68F60.EpsilonRepr << 45)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static U17F15 UncheckedLossyFrom(I68F60 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I68F60.EpsilonRepr << 45)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        public static U17F15? CheckedLossyFrom(I68F60 from) {
-            var tmp = from.Bits / (I68F60.EpsilonRepr << 45);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U17F15(I68F60 from) {
+            return FromBits((uint)(from.Bits / (I68F60.EpsilonRepr << 45)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -652,230 +349,55 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U17F15 StrictLossyFrom(I8F120 from) {
-            return FromBits(checked((uint)(from.Bits / (I8F120.EpsilonRepr << 105)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U17F15 UncheckedLossyFrom(I8F120 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I8F120.EpsilonRepr << 105)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        public static U17F15? CheckedLossyFrom(I8F120 from) {
-            var tmp = from.Bits / (I8F120.EpsilonRepr << 105);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U17F15(I8F120 from) {
+            return FromBits((uint)(from.Bits / (I8F120.EpsilonRepr << 105)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U17F15 LossyFrom(U2F30 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U2F30.EpsilonRepr << 15)))
-            );
+        public static explicit operator U17F15(U2F30 from) {
+            return FromBits((uint)(from.Bits / (U2F30.EpsilonRepr << 15)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U34F30)"/>
-        /// <seealso cref="CheckedLossyFrom(U34F30)"/>
-        public static U17F15 StrictLossyFrom(U34F30 from) {
-            return FromBits(checked((uint)(from.Bits / (U34F30.EpsilonRepr << 15)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U34F30)"/>
-        /// <seealso cref="CheckedLossyFrom(U34F30)"/>
-        public static U17F15 UncheckedLossyFrom(U34F30 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U34F30.EpsilonRepr << 15)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U34F30)"/>
-        /// <seealso cref="UncheckedLossyFrom(U34F30)"/>
-        public static U17F15? CheckedLossyFrom(U34F30 from) {
-            var tmp = from.Bits / (U34F30.EpsilonRepr << 15);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U17F15(U34F30 from) {
+            return FromBits((uint)(from.Bits / (U34F30.EpsilonRepr << 15)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(U33F31)"/>
-        public static U17F15 StrictLossyFrom(U33F31 from) {
-            return FromBits(checked((uint)(from.Bits / (U33F31.EpsilonRepr << 16)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(U33F31)"/>
-        public static U17F15 UncheckedLossyFrom(U33F31 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U33F31.EpsilonRepr << 16)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U33F31)"/>
-        /// <seealso cref="UncheckedLossyFrom(U33F31)"/>
-        public static U17F15? CheckedLossyFrom(U33F31 from) {
-            var tmp = from.Bits / (U33F31.EpsilonRepr << 16);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U17F15(U33F31 from) {
+            return FromBits((uint)(from.Bits / (U33F31.EpsilonRepr << 16)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U17F15 LossyFrom(U4F60 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U4F60.EpsilonRepr << 45)))
-            );
+        public static explicit operator U17F15(U4F60 from) {
+            return FromBits((uint)(from.Bits / (U4F60.EpsilonRepr << 45)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U17F15 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U2F62.EpsilonRepr << 47)))
-            );
+        public static explicit operator U17F15(U2F62 from) {
+            return FromBits((uint)(from.Bits / (U2F62.EpsilonRepr << 47)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static U17F15 StrictLossyFrom(U68F60 from) {
-            return FromBits(checked((uint)(from.Bits / (U68F60.EpsilonRepr << 45)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static U17F15 UncheckedLossyFrom(U68F60 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U68F60.EpsilonRepr << 45)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        public static U17F15? CheckedLossyFrom(U68F60 from) {
-            var tmp = from.Bits / (U68F60.EpsilonRepr << 45);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U17F15(U68F60 from) {
+            return FromBits((uint)(from.Bits / (U68F60.EpsilonRepr << 45)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -884,11 +406,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U17F15 LossyFrom(U8F120 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U8F120.EpsilonRepr << 105)))
-            );
+        public static explicit operator U17F15(U8F120 from) {
+            return FromBits((uint)(from.Bits / (U8F120.EpsilonRepr << 105)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/U2F30.gen.cs
+++ b/Intar/U2F30.gen.cs
@@ -290,364 +290,57 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U2F30 StrictFrom(I17F15 from) {
-            return FromBits(checked((uint)from.Bits * (EpsilonRepr << 15))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U2F30 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((uint)from.Bits * (EpsilonRepr << 15))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static U2F30? CheckedFrom(I17F15 from) {
-            const int shift = 15;
-            const uint k = EpsilonRepr << shift;
-            const uint max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((uint)from.Bits * k);
+        public static explicit operator U2F30(I17F15 from) {
+            return FromBits((uint)from.Bits * (EpsilonRepr << 15));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U2F30 StrictFrom(I2F30 from) {
-            return FromBits(checked((uint)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U2F30 UncheckedFrom(I2F30 from) {
-            return FromBits(unchecked((uint)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        public static U2F30? CheckedFrom(I2F30 from) {
-            const int shift = 0;
-            const uint k = EpsilonRepr << shift;
-            const uint max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((uint)from.Bits * k);
+        public static explicit operator U2F30(I2F30 from) {
+            return FromBits((uint)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U2F30 StrictFrom(I34F30 from) {
-            return FromBits(checked((uint)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U2F30 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((uint)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static U2F30? CheckedFrom(I34F30 from) {
-            const int shift = 0;
-            const uint k = EpsilonRepr << shift;
-            const uint max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((uint)from.Bits * k);
+        public static explicit operator U2F30(I34F30 from) {
+            return FromBits((uint)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(I33F31)"/>
-        public static U2F30 StrictLossyFrom(I33F31 from) {
-            return FromBits(checked((uint)(from.Bits / (I33F31.EpsilonRepr << 1)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(I33F31)"/>
-        public static U2F30 UncheckedLossyFrom(I33F31 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I33F31.EpsilonRepr << 1)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I33F31)"/>
-        /// <seealso cref="UncheckedLossyFrom(I33F31)"/>
-        public static U2F30? CheckedLossyFrom(I33F31 from) {
-            var tmp = from.Bits / (I33F31.EpsilonRepr << 1);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U2F30(I33F31 from) {
+            return FromBits((uint)(from.Bits / (I33F31.EpsilonRepr << 1)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I4F60)"/>
-        public static U2F30 StrictLossyFrom(I4F60 from) {
-            return FromBits(checked((uint)(from.Bits / (I4F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I4F60)"/>
-        public static U2F30 UncheckedLossyFrom(I4F60 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I4F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I4F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I4F60)"/>
-        public static U2F30? CheckedLossyFrom(I4F60 from) {
-            var tmp = from.Bits / (I4F60.EpsilonRepr << 30);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U2F30(I4F60 from) {
+            return FromBits((uint)(from.Bits / (I4F60.EpsilonRepr << 30)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U2F30 StrictLossyFrom(I2F62 from) {
-            return FromBits(checked((uint)(from.Bits / (I2F62.EpsilonRepr << 32)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U2F30 UncheckedLossyFrom(I2F62 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I2F62.EpsilonRepr << 32)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        public static U2F30? CheckedLossyFrom(I2F62 from) {
-            var tmp = from.Bits / (I2F62.EpsilonRepr << 32);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U2F30(I2F62 from) {
+            return FromBits((uint)(from.Bits / (I2F62.EpsilonRepr << 32)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static U2F30 StrictLossyFrom(I68F60 from) {
-            return FromBits(checked((uint)(from.Bits / (I68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static U2F30 UncheckedLossyFrom(I68F60 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        public static U2F30? CheckedLossyFrom(I68F60 from) {
-            var tmp = from.Bits / (I68F60.EpsilonRepr << 30);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U2F30(I68F60 from) {
+            return FromBits((uint)(from.Bits / (I68F60.EpsilonRepr << 30)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -656,316 +349,55 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U2F30 StrictLossyFrom(I8F120 from) {
-            return FromBits(checked((uint)(from.Bits / (I8F120.EpsilonRepr << 90)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U2F30 UncheckedLossyFrom(I8F120 from) {
-            return FromBits(unchecked((uint)(from.Bits / (I8F120.EpsilonRepr << 90)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        public static U2F30? CheckedLossyFrom(I8F120 from) {
-            var tmp = from.Bits / (I8F120.EpsilonRepr << 90);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U2F30(I8F120 from) {
+            return FromBits((uint)(from.Bits / (I8F120.EpsilonRepr << 90)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static U2F30 StrictFrom(U17F15 from) {
-            return FromBits(checked((uint)from.Bits * (EpsilonRepr << 15))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static U2F30 UncheckedFrom(U17F15 from) {
-            return FromBits(unchecked((uint)from.Bits * (EpsilonRepr << 15))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        public static U2F30? CheckedFrom(U17F15 from) {
-            const int shift = 15;
-            const uint k = EpsilonRepr << shift;
-            const uint max = MaxRepr / k;
-            const uint min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((uint)from.Bits * k);
+        public static explicit operator U2F30(U17F15 from) {
+            return FromBits((uint)from.Bits * (EpsilonRepr << 15));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static U2F30 StrictFrom(U34F30 from) {
-            return FromBits(checked((uint)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static U2F30 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((uint)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static U2F30? CheckedFrom(U34F30 from) {
-            const int shift = 0;
-            const uint k = EpsilonRepr << shift;
-            const uint max = MaxRepr / k;
-            const uint min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((uint)from.Bits * k);
+        public static explicit operator U2F30(U34F30 from) {
+            return FromBits((uint)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(U33F31)"/>
-        public static U2F30 StrictLossyFrom(U33F31 from) {
-            return FromBits(checked((uint)(from.Bits / (U33F31.EpsilonRepr << 1)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(U33F31)"/>
-        public static U2F30 UncheckedLossyFrom(U33F31 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U33F31.EpsilonRepr << 1)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U33F31)"/>
-        /// <seealso cref="UncheckedLossyFrom(U33F31)"/>
-        public static U2F30? CheckedLossyFrom(U33F31 from) {
-            var tmp = from.Bits / (U33F31.EpsilonRepr << 1);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U2F30(U33F31 from) {
+            return FromBits((uint)(from.Bits / (U33F31.EpsilonRepr << 1)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U4F60)"/>
-        public static U2F30 StrictLossyFrom(U4F60 from) {
-            return FromBits(checked((uint)(from.Bits / (U4F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U4F60)"/>
-        public static U2F30 UncheckedLossyFrom(U4F60 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U4F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U4F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(U4F60)"/>
-        public static U2F30? CheckedLossyFrom(U4F60 from) {
-            var tmp = from.Bits / (U4F60.EpsilonRepr << 30);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U2F30(U4F60 from) {
+            return FromBits((uint)(from.Bits / (U4F60.EpsilonRepr << 30)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U2F30 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U2F62.EpsilonRepr << 32)))
-            );
+        public static explicit operator U2F30(U2F62 from) {
+            return FromBits((uint)(from.Bits / (U2F62.EpsilonRepr << 32)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static U2F30 StrictLossyFrom(U68F60 from) {
-            return FromBits(checked((uint)(from.Bits / (U68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static U2F30 UncheckedLossyFrom(U68F60 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        public static U2F30? CheckedLossyFrom(U68F60 from) {
-            var tmp = from.Bits / (U68F60.EpsilonRepr << 30);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U2F30(U68F60 from) {
+            return FromBits((uint)(from.Bits / (U68F60.EpsilonRepr << 30)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -974,51 +406,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static U2F30 StrictLossyFrom(U8F120 from) {
-            return FromBits(checked((uint)(from.Bits / (U8F120.EpsilonRepr << 90)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static U2F30 UncheckedLossyFrom(U8F120 from) {
-            return FromBits(unchecked((uint)(from.Bits / (U8F120.EpsilonRepr << 90)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        public static U2F30? CheckedLossyFrom(U8F120 from) {
-            var tmp = from.Bits / (U8F120.EpsilonRepr << 90);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((uint)tmp);
+        public static explicit operator U2F30(U8F120 from) {
+            return FromBits((uint)(from.Bits / (U8F120.EpsilonRepr << 90)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/U2F62.gen.cs
+++ b/Intar/U2F62.gen.cs
@@ -291,372 +291,57 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U2F62 StrictFrom(I17F15 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 47))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U2F62 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 47))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static U2F62? CheckedFrom(I17F15 from) {
-            const int shift = 47;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(I17F15 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 47));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U2F62 StrictFrom(I2F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U2F62 UncheckedFrom(I2F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        public static U2F62? CheckedFrom(I2F30 from) {
-            const int shift = 32;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(I2F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 32));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U2F62 StrictFrom(I34F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U2F62 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static U2F62? CheckedFrom(I34F30 from) {
-            const int shift = 32;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(I34F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 32));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static U2F62 StrictFrom(I33F31 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 31))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static U2F62 UncheckedFrom(I33F31 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 31))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        public static U2F62? CheckedFrom(I33F31 from) {
-            const int shift = 31;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(I33F31 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 31));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I4F60)"/>
-        /// <seealso cref="CheckedFrom(I4F60)"/>
-        public static U2F62 StrictFrom(I4F60 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I4F60)"/>
-        /// <seealso cref="CheckedFrom(I4F60)"/>
-        public static U2F62 UncheckedFrom(I4F60 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I4F60)"/>
-        /// <seealso cref="UncheckedFrom(I4F60)"/>
-        public static U2F62? CheckedFrom(I4F60 from) {
-            const int shift = 2;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(I4F60 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 2));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I2F62)"/>
-        /// <seealso cref="CheckedFrom(I2F62)"/>
-        public static U2F62 StrictFrom(I2F62 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F62)"/>
-        /// <seealso cref="CheckedFrom(I2F62)"/>
-        public static U2F62 UncheckedFrom(I2F62 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F62)"/>
-        /// <seealso cref="UncheckedFrom(I2F62)"/>
-        public static U2F62? CheckedFrom(I2F62 from) {
-            const int shift = 0;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(I2F62 from) {
+            return FromBits((ulong)from.Bits);
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static U2F62 StrictFrom(I68F60 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static U2F62 UncheckedFrom(I68F60 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        public static U2F62? CheckedFrom(I68F60 from) {
-            const int shift = 2;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((UInt128)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(I68F60 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 2));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -665,325 +350,55 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U2F62 StrictLossyFrom(I8F120 from) {
-            return FromBits(checked((ulong)(from.Bits / (I8F120.EpsilonRepr << 58)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U2F62 UncheckedLossyFrom(I8F120 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I8F120.EpsilonRepr << 58)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        public static U2F62? CheckedLossyFrom(I8F120 from) {
-            var tmp = from.Bits / (I8F120.EpsilonRepr << 58);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U2F62(I8F120 from) {
+            return FromBits((ulong)(from.Bits / (I8F120.EpsilonRepr << 58)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static U2F62 StrictFrom(U17F15 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 47))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static U2F62 UncheckedFrom(U17F15 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 47))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        public static U2F62? CheckedFrom(U17F15 from) {
-            const int shift = 47;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            const ulong min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(U17F15 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 47));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U2F62 From(U2F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 32))
-            );
+        public static explicit operator U2F62(U2F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 32));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static U2F62 StrictFrom(U34F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static U2F62 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 32))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static U2F62? CheckedFrom(U34F30 from) {
-            const int shift = 32;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            const ulong min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(U34F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 32));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static U2F62 StrictFrom(U33F31 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 31))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static U2F62 UncheckedFrom(U33F31 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 31))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        public static U2F62? CheckedFrom(U33F31 from) {
-            const int shift = 31;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            const ulong min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(U33F31 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 31));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U4F60)"/>
-        /// <seealso cref="CheckedFrom(U4F60)"/>
-        public static U2F62 StrictFrom(U4F60 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U4F60)"/>
-        /// <seealso cref="CheckedFrom(U4F60)"/>
-        public static U2F62 UncheckedFrom(U4F60 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U4F60)"/>
-        /// <seealso cref="UncheckedFrom(U4F60)"/>
-        public static U2F62? CheckedFrom(U4F60 from) {
-            const int shift = 2;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            const ulong min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(U4F60 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 2));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static U2F62 StrictFrom(U68F60 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static U2F62 UncheckedFrom(U68F60 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 2))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        public static U2F62? CheckedFrom(U68F60 from) {
-            const int shift = 2;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            const ulong min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U2F62(U68F60 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 2));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -992,51 +407,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static U2F62 StrictLossyFrom(U8F120 from) {
-            return FromBits(checked((ulong)(from.Bits / (U8F120.EpsilonRepr << 58)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static U2F62 UncheckedLossyFrom(U8F120 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U8F120.EpsilonRepr << 58)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        public static U2F62? CheckedLossyFrom(U8F120 from) {
-            var tmp = from.Bits / (U8F120.EpsilonRepr << 58);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U2F62(U8F120 from) {
+            return FromBits((ulong)(from.Bits / (U8F120.EpsilonRepr << 58)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/U33F31.gen.cs
+++ b/Intar/U33F31.gen.cs
@@ -291,366 +291,57 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U33F31 StrictFrom(I17F15 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 16))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U33F31 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 16))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static U33F31? CheckedFrom(I17F15 from) {
-            const int shift = 16;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U33F31(I17F15 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 16));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U33F31 StrictFrom(I2F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 1))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U33F31 UncheckedFrom(I2F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 1))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        public static U33F31? CheckedFrom(I2F30 from) {
-            const int shift = 1;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U33F31(I2F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 1));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U33F31 StrictFrom(I34F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 1))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U33F31 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 1))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static U33F31? CheckedFrom(I34F30 from) {
-            const int shift = 1;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U33F31(I34F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 1));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static U33F31 StrictFrom(I33F31 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static U33F31 UncheckedFrom(I33F31 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        public static U33F31? CheckedFrom(I33F31 from) {
-            const int shift = 0;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U33F31(I33F31 from) {
+            return FromBits((ulong)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I4F60)"/>
-        public static U33F31 StrictLossyFrom(I4F60 from) {
-            return FromBits(checked((ulong)(from.Bits / (I4F60.EpsilonRepr << 29)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I4F60)"/>
-        public static U33F31 UncheckedLossyFrom(I4F60 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I4F60.EpsilonRepr << 29)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I4F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I4F60)"/>
-        public static U33F31? CheckedLossyFrom(I4F60 from) {
-            var tmp = from.Bits / (I4F60.EpsilonRepr << 29);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U33F31(I4F60 from) {
+            return FromBits((ulong)(from.Bits / (I4F60.EpsilonRepr << 29)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U33F31 StrictLossyFrom(I2F62 from) {
-            return FromBits(checked((ulong)(from.Bits / (I2F62.EpsilonRepr << 31)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U33F31 UncheckedLossyFrom(I2F62 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I2F62.EpsilonRepr << 31)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        public static U33F31? CheckedLossyFrom(I2F62 from) {
-            var tmp = from.Bits / (I2F62.EpsilonRepr << 31);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U33F31(I2F62 from) {
+            return FromBits((ulong)(from.Bits / (I2F62.EpsilonRepr << 31)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static U33F31 StrictLossyFrom(I68F60 from) {
-            return FromBits(checked((ulong)(from.Bits / (I68F60.EpsilonRepr << 29)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static U33F31 UncheckedLossyFrom(I68F60 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I68F60.EpsilonRepr << 29)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        public static U33F31? CheckedLossyFrom(I68F60 from) {
-            var tmp = from.Bits / (I68F60.EpsilonRepr << 29);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U33F31(I68F60 from) {
+            return FromBits((ulong)(from.Bits / (I68F60.EpsilonRepr << 29)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -659,193 +350,55 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U33F31 StrictLossyFrom(I8F120 from) {
-            return FromBits(checked((ulong)(from.Bits / (I8F120.EpsilonRepr << 89)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U33F31 UncheckedLossyFrom(I8F120 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I8F120.EpsilonRepr << 89)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        public static U33F31? CheckedLossyFrom(I8F120 from) {
-            var tmp = from.Bits / (I8F120.EpsilonRepr << 89);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U33F31(I8F120 from) {
+            return FromBits((ulong)(from.Bits / (I8F120.EpsilonRepr << 89)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U33F31 From(U17F15 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 16))
-            );
+        public static explicit operator U33F31(U17F15 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 16));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U33F31 From(U2F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 1))
-            );
+        public static explicit operator U33F31(U2F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 1));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static U33F31 StrictFrom(U34F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 1))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static U33F31 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 1))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static U33F31? CheckedFrom(U34F30 from) {
-            const int shift = 1;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            const ulong min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U33F31(U34F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 1));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U33F31 LossyFrom(U4F60 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U4F60.EpsilonRepr << 29)))
-            );
+        public static explicit operator U33F31(U4F60 from) {
+            return FromBits((ulong)(from.Bits / (U4F60.EpsilonRepr << 29)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U33F31 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U2F62.EpsilonRepr << 31)))
-            );
+        public static explicit operator U33F31(U2F62 from) {
+            return FromBits((ulong)(from.Bits / (U2F62.EpsilonRepr << 31)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static U33F31 StrictLossyFrom(U68F60 from) {
-            return FromBits(checked((ulong)(from.Bits / (U68F60.EpsilonRepr << 29)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static U33F31 UncheckedLossyFrom(U68F60 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U68F60.EpsilonRepr << 29)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        public static U33F31? CheckedLossyFrom(U68F60 from) {
-            var tmp = from.Bits / (U68F60.EpsilonRepr << 29);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U33F31(U68F60 from) {
+            return FromBits((ulong)(from.Bits / (U68F60.EpsilonRepr << 29)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -854,11 +407,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U33F31 LossyFrom(U8F120 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U8F120.EpsilonRepr << 89)))
-            );
+        public static explicit operator U33F31(U8F120 from) {
+            return FromBits((ulong)(from.Bits / (U8F120.EpsilonRepr << 89)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/U34F30.gen.cs
+++ b/Intar/U34F30.gen.cs
@@ -305,364 +305,57 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U34F30 StrictFrom(I17F15 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 15))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U34F30 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 15))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static U34F30? CheckedFrom(I17F15 from) {
-            const int shift = 15;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U34F30(I17F15 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 15));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U34F30 StrictFrom(I2F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U34F30 UncheckedFrom(I2F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        public static U34F30? CheckedFrom(I2F30 from) {
-            const int shift = 0;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U34F30(I2F30 from) {
+            return FromBits((ulong)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U34F30 StrictFrom(I34F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U34F30 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static U34F30? CheckedFrom(I34F30 from) {
-            const int shift = 0;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U34F30(I34F30 from) {
+            return FromBits((ulong)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(I33F31)"/>
-        public static U34F30 StrictLossyFrom(I33F31 from) {
-            return FromBits(checked((ulong)(from.Bits / (I33F31.EpsilonRepr << 1)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I33F31)"/>
-        /// <seealso cref="CheckedLossyFrom(I33F31)"/>
-        public static U34F30 UncheckedLossyFrom(I33F31 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I33F31.EpsilonRepr << 1)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I33F31)"/>
-        /// <seealso cref="UncheckedLossyFrom(I33F31)"/>
-        public static U34F30? CheckedLossyFrom(I33F31 from) {
-            var tmp = from.Bits / (I33F31.EpsilonRepr << 1);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U34F30(I33F31 from) {
+            return FromBits((ulong)(from.Bits / (I33F31.EpsilonRepr << 1)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I4F60)"/>
-        public static U34F30 StrictLossyFrom(I4F60 from) {
-            return FromBits(checked((ulong)(from.Bits / (I4F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I4F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I4F60)"/>
-        public static U34F30 UncheckedLossyFrom(I4F60 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I4F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I4F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I4F60)"/>
-        public static U34F30? CheckedLossyFrom(I4F60 from) {
-            var tmp = from.Bits / (I4F60.EpsilonRepr << 30);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U34F30(I4F60 from) {
+            return FromBits((ulong)(from.Bits / (I4F60.EpsilonRepr << 30)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U34F30 StrictLossyFrom(I2F62 from) {
-            return FromBits(checked((ulong)(from.Bits / (I2F62.EpsilonRepr << 32)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U34F30 UncheckedLossyFrom(I2F62 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I2F62.EpsilonRepr << 32)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        public static U34F30? CheckedLossyFrom(I2F62 from) {
-            var tmp = from.Bits / (I2F62.EpsilonRepr << 32);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U34F30(I2F62 from) {
+            return FromBits((ulong)(from.Bits / (I2F62.EpsilonRepr << 32)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static U34F30 StrictLossyFrom(I68F60 from) {
-            return FromBits(checked((ulong)(from.Bits / (I68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(I68F60)"/>
-        public static U34F30 UncheckedLossyFrom(I68F60 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(I68F60)"/>
-        public static U34F30? CheckedLossyFrom(I68F60 from) {
-            var tmp = from.Bits / (I68F60.EpsilonRepr << 30);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U34F30(I68F60 from) {
+            return FromBits((ulong)(from.Bits / (I68F60.EpsilonRepr << 30)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -671,150 +364,55 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U34F30 StrictLossyFrom(I8F120 from) {
-            return FromBits(checked((ulong)(from.Bits / (I8F120.EpsilonRepr << 90)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U34F30 UncheckedLossyFrom(I8F120 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I8F120.EpsilonRepr << 90)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        public static U34F30? CheckedLossyFrom(I8F120 from) {
-            var tmp = from.Bits / (I8F120.EpsilonRepr << 90);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U34F30(I8F120 from) {
+            return FromBits((ulong)(from.Bits / (I8F120.EpsilonRepr << 90)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U34F30 From(U17F15 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 15))
-            );
+        public static explicit operator U34F30(U17F15 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 15));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U34F30 From(U2F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
+        public static explicit operator U34F30(U2F30 from) {
+            return FromBits((ulong)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U34F30 LossyFrom(U33F31 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U33F31.EpsilonRepr << 1)))
-            );
+        public static explicit operator U34F30(U33F31 from) {
+            return FromBits((ulong)(from.Bits / (U33F31.EpsilonRepr << 1)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U34F30 LossyFrom(U4F60 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U4F60.EpsilonRepr << 30)))
-            );
+        public static explicit operator U34F30(U4F60 from) {
+            return FromBits((ulong)(from.Bits / (U4F60.EpsilonRepr << 30)));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U34F30 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U2F62.EpsilonRepr << 32)))
-            );
+        public static explicit operator U34F30(U2F62 from) {
+            return FromBits((ulong)(from.Bits / (U2F62.EpsilonRepr << 32)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static U34F30 StrictLossyFrom(U68F60 from) {
-            return FromBits(checked((ulong)(from.Bits / (U68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="CheckedLossyFrom(U68F60)"/>
-        public static U34F30 UncheckedLossyFrom(U68F60 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U68F60.EpsilonRepr << 30)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U68F60)"/>
-        /// <seealso cref="UncheckedLossyFrom(U68F60)"/>
-        public static U34F30? CheckedLossyFrom(U68F60 from) {
-            var tmp = from.Bits / (U68F60.EpsilonRepr << 30);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U34F30(U68F60 from) {
+            return FromBits((ulong)(from.Bits / (U68F60.EpsilonRepr << 30)));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -823,11 +421,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U34F30 LossyFrom(U8F120 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U8F120.EpsilonRepr << 90)))
-            );
+        public static explicit operator U34F30(U8F120 from) {
+            return FromBits((ulong)(from.Bits / (U8F120.EpsilonRepr << 90)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/U4F60.gen.cs
+++ b/Intar/U4F60.gen.cs
@@ -305,370 +305,57 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U4F60 StrictFrom(I17F15 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 45))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U4F60 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 45))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static U4F60? CheckedFrom(I17F15 from) {
-            const int shift = 45;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U4F60(I17F15 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 45));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U4F60 StrictFrom(I2F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U4F60 UncheckedFrom(I2F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        public static U4F60? CheckedFrom(I2F30 from) {
-            const int shift = 30;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U4F60(I2F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U4F60 StrictFrom(I34F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U4F60 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static U4F60? CheckedFrom(I34F30 from) {
-            const int shift = 30;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U4F60(I34F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static U4F60 StrictFrom(I33F31 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 29))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static U4F60 UncheckedFrom(I33F31 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 29))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        public static U4F60? CheckedFrom(I33F31 from) {
-            const int shift = 29;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U4F60(I33F31 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 29));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I4F60)"/>
-        /// <seealso cref="CheckedFrom(I4F60)"/>
-        public static U4F60 StrictFrom(I4F60 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I4F60)"/>
-        /// <seealso cref="CheckedFrom(I4F60)"/>
-        public static U4F60 UncheckedFrom(I4F60 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I4F60)"/>
-        /// <seealso cref="UncheckedFrom(I4F60)"/>
-        public static U4F60? CheckedFrom(I4F60 from) {
-            const int shift = 0;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U4F60(I4F60 from) {
+            return FromBits((ulong)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U4F60 StrictLossyFrom(I2F62 from) {
-            return FromBits(checked((ulong)(from.Bits / (I2F62.EpsilonRepr << 2)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U4F60 UncheckedLossyFrom(I2F62 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I2F62.EpsilonRepr << 2)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        public static U4F60? CheckedLossyFrom(I2F62 from) {
-            var tmp = from.Bits / (I2F62.EpsilonRepr << 2);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U4F60(I2F62 from) {
+            return FromBits((ulong)(from.Bits / (I2F62.EpsilonRepr << 2)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static U4F60 StrictFrom(I68F60 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static U4F60 UncheckedFrom(I68F60 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        public static U4F60? CheckedFrom(I68F60 from) {
-            const int shift = 0;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((UInt128)from.Bits > max) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U4F60(I68F60 from) {
+            return FromBits((ulong)from.Bits);
         }
 
 #endif // NET7_0_OR_GREATER
@@ -677,282 +364,55 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U4F60 StrictLossyFrom(I8F120 from) {
-            return FromBits(checked((ulong)(from.Bits / (I8F120.EpsilonRepr << 60)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U4F60 UncheckedLossyFrom(I8F120 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (I8F120.EpsilonRepr << 60)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        public static U4F60? CheckedLossyFrom(I8F120 from) {
-            var tmp = from.Bits / (I8F120.EpsilonRepr << 60);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U4F60(I8F120 from) {
+            return FromBits((ulong)(from.Bits / (I8F120.EpsilonRepr << 60)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static U4F60 StrictFrom(U17F15 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 45))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static U4F60 UncheckedFrom(U17F15 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 45))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        public static U4F60? CheckedFrom(U17F15 from) {
-            const int shift = 45;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            const ulong min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U4F60(U17F15 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 45));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U4F60 From(U2F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 30))
-            );
+        public static explicit operator U4F60(U2F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static U4F60 StrictFrom(U34F30 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static U4F60 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static U4F60? CheckedFrom(U34F30 from) {
-            const int shift = 30;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            const ulong min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U4F60(U34F30 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static U4F60 StrictFrom(U33F31 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 29))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static U4F60 UncheckedFrom(U33F31 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 29))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        public static U4F60? CheckedFrom(U33F31 from) {
-            const int shift = 29;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            const ulong min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U4F60(U33F31 from) {
+            return FromBits((ulong)from.Bits * (EpsilonRepr << 29));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U4F60 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U2F62.EpsilonRepr << 2)))
-            );
+        public static explicit operator U4F60(U2F62 from) {
+            return FromBits((ulong)(from.Bits / (U2F62.EpsilonRepr << 2)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static U4F60 StrictFrom(U68F60 from) {
-            return FromBits(checked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static U4F60 UncheckedFrom(U68F60 from) {
-            return FromBits(unchecked((ulong)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        public static U4F60? CheckedFrom(U68F60 from) {
-            const int shift = 0;
-            const ulong k = EpsilonRepr << shift;
-            const ulong max = MaxRepr / k;
-            const ulong min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((ulong)from.Bits * k);
+        public static explicit operator U4F60(U68F60 from) {
+            return FromBits((ulong)from.Bits);
         }
 
 #endif // NET7_0_OR_GREATER
@@ -961,51 +421,9 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static U4F60 StrictLossyFrom(U8F120 from) {
-            return FromBits(checked((ulong)(from.Bits / (U8F120.EpsilonRepr << 60)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(U8F120)"/>
-        public static U4F60 UncheckedLossyFrom(U8F120 from) {
-            return FromBits(unchecked((ulong)(from.Bits / (U8F120.EpsilonRepr << 60)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(U8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(U8F120)"/>
-        public static U4F60? CheckedLossyFrom(U8F120 from) {
-            var tmp = from.Bits / (U8F120.EpsilonRepr << 60);
-            if (tmp < MinRepr ||
-                tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((ulong)tmp);
+        public static explicit operator U4F60(U8F120 from) {
+            return FromBits((ulong)(from.Bits / (U8F120.EpsilonRepr << 60)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/U68F60.gen.cs
+++ b/Intar/U68F60.gen.cs
@@ -255,370 +255,57 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U68F60 StrictFrom(I17F15 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 45))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U68F60 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 45))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static U68F60? CheckedFrom(I17F15 from) {
-            const int shift = 45;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U68F60(I17F15 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 45));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U68F60 StrictFrom(I2F30 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U68F60 UncheckedFrom(I2F30 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        public static U68F60? CheckedFrom(I2F30 from) {
-            const int shift = 30;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U68F60(I2F30 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U68F60 StrictFrom(I34F30 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U68F60 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 30))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static U68F60? CheckedFrom(I34F30 from) {
-            const int shift = 30;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U68F60(I34F30 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static U68F60 StrictFrom(I33F31 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 29))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static U68F60 UncheckedFrom(I33F31 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 29))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        public static U68F60? CheckedFrom(I33F31 from) {
-            const int shift = 29;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U68F60(I33F31 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 29));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I4F60)"/>
-        /// <seealso cref="CheckedFrom(I4F60)"/>
-        public static U68F60 StrictFrom(I4F60 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I4F60)"/>
-        /// <seealso cref="CheckedFrom(I4F60)"/>
-        public static U68F60 UncheckedFrom(I4F60 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I4F60)"/>
-        /// <seealso cref="UncheckedFrom(I4F60)"/>
-        public static U68F60? CheckedFrom(I4F60 from) {
-            const int shift = 0;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U68F60(I4F60 from) {
+            return FromBits((UInt128)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U68F60 StrictLossyFrom(I2F62 from) {
-            return FromBits(checked((UInt128)(from.Bits / (I2F62.EpsilonRepr << 2)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="CheckedLossyFrom(I2F62)"/>
-        public static U68F60 UncheckedLossyFrom(I2F62 from) {
-            return FromBits(unchecked((UInt128)(from.Bits / (I2F62.EpsilonRepr << 2)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I2F62)"/>
-        /// <seealso cref="UncheckedLossyFrom(I2F62)"/>
-        public static U68F60? CheckedLossyFrom(I2F62 from) {
-            var tmp = from.Bits / (I2F62.EpsilonRepr << 2);
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((UInt128)tmp);
+        public static explicit operator U68F60(I2F62 from) {
+            return FromBits((UInt128)(from.Bits / (I2F62.EpsilonRepr << 2)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static U68F60 StrictFrom(I68F60 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static U68F60 UncheckedFrom(I68F60 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        public static U68F60? CheckedFrom(I68F60 from) {
-            const int shift = 0;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((UInt128)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U68F60(I68F60 from) {
+            return FromBits((UInt128)from.Bits);
         }
 
 #endif // NET7_0_OR_GREATER
@@ -627,119 +314,62 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U68F60 StrictLossyFrom(I8F120 from) {
-            return FromBits(checked((UInt128)(from.Bits / (I8F120.EpsilonRepr << 60)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="CheckedLossyFrom(I8F120)"/>
-        public static U68F60 UncheckedLossyFrom(I8F120 from) {
-            return FromBits(unchecked((UInt128)(from.Bits / (I8F120.EpsilonRepr << 60)))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictLossyFrom(I8F120)"/>
-        /// <seealso cref="UncheckedLossyFrom(I8F120)"/>
-        public static U68F60? CheckedLossyFrom(I8F120 from) {
-            var tmp = from.Bits / (I8F120.EpsilonRepr << 60);
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > MaxRepr) {
-                return null;
-            }
-            return FromBits((UInt128)tmp);
+        public static explicit operator U68F60(I8F120 from) {
+            return FromBits((UInt128)(from.Bits / (I8F120.EpsilonRepr << 60)));
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U68F60 From(U17F15 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 45))
-            );
+        public static explicit operator U68F60(U17F15 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 45));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U68F60 From(U2F30 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 30))
-            );
+        public static explicit operator U68F60(U2F30 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U68F60 From(U34F30 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 30))
-            );
+        public static explicit operator U68F60(U34F30 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 30));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U68F60 From(U33F31 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 29))
-            );
+        public static explicit operator U68F60(U33F31 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 29));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U68F60 From(U4F60 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 0))
-            );
+        public static explicit operator U68F60(U4F60 from) {
+            return FromBits((UInt128)from.Bits);
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U68F60 LossyFrom(U2F62 from) {
-            return FromBits(unchecked((UInt128)(from.Bits / (U2F62.EpsilonRepr << 2)))
-            );
+        public static explicit operator U68F60(U2F62 from) {
+            return FromBits((UInt128)(from.Bits / (U2F62.EpsilonRepr << 2)));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U8F120" /> value.</para>
-        /// <para><see cref="U8F120" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U68F60 LossyFrom(U8F120 from) {
-            return FromBits(unchecked((UInt128)(from.Bits / (U8F120.EpsilonRepr << 60)))
-            );
+        public static explicit operator U68F60(U8F120 from) {
+            return FromBits((UInt128)(from.Bits / (U8F120.EpsilonRepr << 60)));
         }
 
 #endif // NET7_0_OR_GREATER

--- a/Intar/U8F120.gen.cs
+++ b/Intar/U8F120.gen.cs
@@ -255,372 +255,57 @@ namespace Intar {
 
         #endregion
 
-        #region Convert from fixed-point number
+        #region Conversion from fixed-point number
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U8F120 StrictFrom(I17F15 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 105))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="CheckedFrom(I17F15)"/>
-        public static U8F120 UncheckedFrom(I17F15 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 105))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I17F15" /> value.</para>
-        /// <para><see cref="I17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I17F15)"/>
-        /// <seealso cref="UncheckedFrom(I17F15)"/>
-        public static U8F120? CheckedFrom(I17F15 from) {
-            const int shift = 105;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(I17F15 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 105));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U8F120 StrictFrom(I2F30 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 90))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="CheckedFrom(I2F30)"/>
-        public static U8F120 UncheckedFrom(I2F30 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 90))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F30" /> value.</para>
-        /// <para><see cref="I2F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F30)"/>
-        /// <seealso cref="UncheckedFrom(I2F30)"/>
-        public static U8F120? CheckedFrom(I2F30 from) {
-            const int shift = 90;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((uint)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(I2F30 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 90));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U8F120 StrictFrom(I34F30 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 90))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="CheckedFrom(I34F30)"/>
-        public static U8F120 UncheckedFrom(I34F30 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 90))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I34F30" /> value.</para>
-        /// <para><see cref="I34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I34F30)"/>
-        /// <seealso cref="UncheckedFrom(I34F30)"/>
-        public static U8F120? CheckedFrom(I34F30 from) {
-            const int shift = 90;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(I34F30 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 90));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static U8F120 StrictFrom(I33F31 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 89))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="CheckedFrom(I33F31)"/>
-        public static U8F120 UncheckedFrom(I33F31 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 89))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I33F31" /> value.</para>
-        /// <para><see cref="I33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I33F31)"/>
-        /// <seealso cref="UncheckedFrom(I33F31)"/>
-        public static U8F120? CheckedFrom(I33F31 from) {
-            const int shift = 89;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(I33F31 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 89));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I4F60)"/>
-        /// <seealso cref="CheckedFrom(I4F60)"/>
-        public static U8F120 StrictFrom(I4F60 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 60))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I4F60)"/>
-        /// <seealso cref="CheckedFrom(I4F60)"/>
-        public static U8F120 UncheckedFrom(I4F60 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 60))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I4F60" /> value.</para>
-        /// <para><see cref="I4F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I4F60)"/>
-        /// <seealso cref="UncheckedFrom(I4F60)"/>
-        public static U8F120? CheckedFrom(I4F60 from) {
-            const int shift = 60;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(I4F60 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 60));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I2F62)"/>
-        /// <seealso cref="CheckedFrom(I2F62)"/>
-        public static U8F120 StrictFrom(I2F62 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 58))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F62)"/>
-        /// <seealso cref="CheckedFrom(I2F62)"/>
-        public static U8F120 UncheckedFrom(I2F62 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 58))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I2F62" /> value.</para>
-        /// <para><see cref="I2F62" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I2F62)"/>
-        /// <seealso cref="UncheckedFrom(I2F62)"/>
-        public static U8F120? CheckedFrom(I2F62 from) {
-            const int shift = 58;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((ulong)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(I2F62 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 58));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static U8F120 StrictFrom(I68F60 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 60))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="CheckedFrom(I68F60)"/>
-        public static U8F120 UncheckedFrom(I68F60 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 60))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I68F60" /> value.</para>
-        /// <para><see cref="I68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I68F60)"/>
-        /// <seealso cref="UncheckedFrom(I68F60)"/>
-        public static U8F120? CheckedFrom(I68F60 from) {
-            const int shift = 60;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((UInt128)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(I68F60 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 60));
         }
 
 #endif // NET7_0_OR_GREATER
@@ -629,293 +314,62 @@ namespace Intar {
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(I8F120)"/>
-        /// <seealso cref="CheckedFrom(I8F120)"/>
-        public static U8F120 StrictFrom(I8F120 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I8F120)"/>
-        /// <seealso cref="CheckedFrom(I8F120)"/>
-        public static U8F120 UncheckedFrom(I8F120 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 0))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="I8F120" /> value.</para>
-        /// <para><see cref="I8F120" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(I8F120)"/>
-        /// <seealso cref="UncheckedFrom(I8F120)"/>
-        public static U8F120? CheckedFrom(I8F120 from) {
-            const int shift = 0;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            if (from.Bits < 0) {
-                return null;
-            } else if ((UInt128)from.Bits > max) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(I8F120 from) {
+            return FromBits((UInt128)from.Bits);
         }
 
 #endif // NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static U8F120 StrictFrom(U17F15 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 105))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="CheckedFrom(U17F15)"/>
-        public static U8F120 UncheckedFrom(U17F15 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 105))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U17F15" /> value.</para>
-        /// <para><see cref="U17F15" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U17F15)"/>
-        /// <seealso cref="UncheckedFrom(U17F15)"/>
-        public static U8F120? CheckedFrom(U17F15 from) {
-            const int shift = 105;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            var min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(U17F15 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 105));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F30" /> value.</para>
-        /// <para><see cref="U2F30" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U8F120 From(U2F30 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 90))
-            );
+        public static explicit operator U8F120(U2F30 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 90));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static U8F120 StrictFrom(U34F30 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 90))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="CheckedFrom(U34F30)"/>
-        public static U8F120 UncheckedFrom(U34F30 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 90))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U34F30" /> value.</para>
-        /// <para><see cref="U34F30" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U34F30)"/>
-        /// <seealso cref="UncheckedFrom(U34F30)"/>
-        public static U8F120? CheckedFrom(U34F30 from) {
-            const int shift = 90;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            var min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(U34F30 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 90));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static U8F120 StrictFrom(U33F31 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 89))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="CheckedFrom(U33F31)"/>
-        public static U8F120 UncheckedFrom(U33F31 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 89))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U33F31" /> value.</para>
-        /// <para><see cref="U33F31" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U33F31)"/>
-        /// <seealso cref="UncheckedFrom(U33F31)"/>
-        public static U8F120? CheckedFrom(U33F31 from) {
-            const int shift = 89;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            var min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(U33F31 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 89));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U4F60" /> value.</para>
-        /// <para><see cref="U4F60" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U8F120 From(U4F60 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 60))
-            );
+        public static explicit operator U8F120(U4F60 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 60));
         }
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U2F62" /> value.</para>
-        /// <para><see cref="U2F62" /> から新しく固定小数点数を構築します。</para>
         /// </summary>
-        public static U8F120 From(U2F62 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 58))
-            );
+        public static explicit operator U8F120(U2F62 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 58));
         }
 
 #if NET7_0_OR_GREATER
 
         /// <summary>
         /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static U8F120 StrictFrom(U68F60 from) {
-            return FromBits(checked((UInt128)from.Bits * (EpsilonRepr << 60))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="CheckedFrom(U68F60)"/>
-        public static U8F120 UncheckedFrom(U68F60 from) {
-            return FromBits(unchecked((UInt128)from.Bits * (EpsilonRepr << 60))
-            );
-        }
-
-        /// <summary>
-        /// <para>Constructs a new fixed-point number from <see cref="U68F60" /> value.</para>
-        /// <para><see cref="U68F60" /> から新しく固定小数点数を構築します。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictFrom(U68F60)"/>
-        /// <seealso cref="UncheckedFrom(U68F60)"/>
-        public static U8F120? CheckedFrom(U68F60 from) {
-            const int shift = 60;
-            var k = EpsilonRepr << shift;
-            var max = MaxRepr / k;
-            var min = MinRepr / k;
-            if (from.Bits > max ||
-                from.Bits < min) {
-                return null;
-            }
-            return FromBits((UInt128)from.Bits * k);
+        public static explicit operator U8F120(U68F60 from) {
+            return FromBits((UInt128)from.Bits * (EpsilonRepr << 60));
         }
 
 #endif // NET7_0_OR_GREATER


### PR DESCRIPTION
専用の静的メソッド
From, StrictFrom, UncheckedFrom, CheckedFrom を廃止し, 一般的な C# の変換演算子のインタフェースに変更した.

これは, 実際のユースケースではオーバーフローが発生することは稀であり,
それらを厳密に取り扱うためのメソッドは過剰実装であるという判断に基づく.