### PR TITLE
整数から固定小数点数への変換を簡略化

### DIFF
--- a/Intar/I17F15.gen.cs
+++ b/Intar/I17F15.gen.cs
@@ -610,134 +610,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
-
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() {
-            return unchecked((int)(Bits / OneRepr));
+        public static explicit operator int(I17F15 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((uint)tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(I17F15 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(I17F15 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong StrictToUInt64() {
-            return checked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(I17F15 v) {
+            return (ulong)(v.Bits / OneRepr);
+        }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(I17F15 v) {
+            return (Int128)(v.Bits / OneRepr);
         }
 
         /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
         /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong UncheckedToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator UInt128(I17F15 v) {
+            return (UInt128)(v.Bits / OneRepr);
         }
 
-        /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="UncheckedToUInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong? CheckedToUInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((uint)tmp > ulong.MaxValue) {
-                return null;
-            }
-
-            return (ulong)tmp;
-        }
-
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/I2F30.gen.cs
+++ b/Intar/I2F30.gen.cs
@@ -460,134 +460,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
-
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() {
-            return unchecked((int)(Bits / OneRepr));
+        public static explicit operator int(I2F30 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((uint)tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(I2F30 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(I2F30 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong StrictToUInt64() {
-            return checked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(I2F30 v) {
+            return (ulong)(v.Bits / OneRepr);
+        }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(I2F30 v) {
+            return (Int128)(v.Bits / OneRepr);
         }
 
         /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
         /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong UncheckedToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator UInt128(I2F30 v) {
+            return (UInt128)(v.Bits / OneRepr);
         }
 
-        /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="UncheckedToUInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong? CheckedToUInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((uint)tmp > ulong.MaxValue) {
-                return null;
-            }
-
-            return (ulong)tmp;
-        }
-
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/I2F62.gen.cs
+++ b/Intar/I2F62.gen.cs
@@ -475,134 +475,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
-
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() {
-            return unchecked((int)(Bits / OneRepr));
+        public static explicit operator int(I2F62 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(I2F62 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(I2F62 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong StrictToUInt64() {
-            return checked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(I2F62 v) {
+            return (ulong)(v.Bits / OneRepr);
+        }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(I2F62 v) {
+            return (Int128)(v.Bits / OneRepr);
         }
 
         /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
         /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong UncheckedToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator UInt128(I2F62 v) {
+            return (UInt128)(v.Bits / OneRepr);
         }
 
-        /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="UncheckedToUInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong? CheckedToUInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > ulong.MaxValue) {
-                return null;
-            }
-
-            return (ulong)tmp;
-        }
-
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/I33F31.gen.cs
+++ b/Intar/I33F31.gen.cs
@@ -702,177 +702,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
 
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
-
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int StrictToInt32() {
-            return checked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int UncheckedToInt32() {
-            return unchecked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="UncheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int? CheckedToInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (tmp < int.MinValue ||
-                tmp > int.MaxValue) {
-                return null;
-            }
-
-            return (int)tmp;
+        public static explicit operator int(I33F31 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(I33F31 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(I33F31 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong StrictToUInt64() {
-            return checked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(I33F31 v) {
+            return (ulong)(v.Bits / OneRepr);
+        }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(I33F31 v) {
+            return (Int128)(v.Bits / OneRepr);
         }
 
         /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
         /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong UncheckedToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator UInt128(I33F31 v) {
+            return (UInt128)(v.Bits / OneRepr);
         }
 
-        /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="UncheckedToUInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong? CheckedToUInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > ulong.MaxValue) {
-                return null;
-            }
-
-            return (ulong)tmp;
-        }
-
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/I34F30.gen.cs
+++ b/Intar/I34F30.gen.cs
@@ -474,177 +474,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
 
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
-
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int StrictToInt32() {
-            return checked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int UncheckedToInt32() {
-            return unchecked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="UncheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int? CheckedToInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (tmp < int.MinValue ||
-                tmp > int.MaxValue) {
-                return null;
-            }
-
-            return (int)tmp;
+        public static explicit operator int(I34F30 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(I34F30 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(I34F30 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong StrictToUInt64() {
-            return checked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(I34F30 v) {
+            return (ulong)(v.Bits / OneRepr);
+        }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(I34F30 v) {
+            return (Int128)(v.Bits / OneRepr);
         }
 
         /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
         /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong UncheckedToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator UInt128(I34F30 v) {
+            return (UInt128)(v.Bits / OneRepr);
         }
 
-        /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="UncheckedToUInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong? CheckedToUInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > ulong.MaxValue) {
-                return null;
-            }
-
-            return (ulong)tmp;
-        }
-
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/I4F60.gen.cs
+++ b/Intar/I4F60.gen.cs
@@ -474,134 +474,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
-
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() {
-            return unchecked((int)(Bits / OneRepr));
+        public static explicit operator int(I4F60 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(I4F60 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(I4F60 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong StrictToUInt64() {
-            return checked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(I4F60 v) {
+            return (ulong)(v.Bits / OneRepr);
+        }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(I4F60 v) {
+            return (Int128)(v.Bits / OneRepr);
         }
 
         /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
         /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong UncheckedToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator UInt128(I4F60 v) {
+            return (UInt128)(v.Bits / OneRepr);
         }
 
-        /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="UncheckedToUInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong? CheckedToUInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((ulong)tmp > ulong.MaxValue) {
-                return null;
-            }
-
-            return (ulong)tmp;
-        }
-
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/I68F60.gen.cs
+++ b/Intar/I68F60.gen.cs
@@ -391,220 +391,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
 
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
-
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int StrictToInt32() {
-            return checked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int UncheckedToInt32() {
-            return unchecked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="UncheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int? CheckedToInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (tmp < int.MinValue ||
-                tmp > int.MaxValue) {
-                return null;
-            }
-
-            return (int)tmp;
+        public static explicit operator int(I68F60 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(I68F60 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToInt64"/>
-        /// <seealso cref="CheckedToInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long StrictToInt64() {
-            return checked((long)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="long" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt64"/>
-        /// <seealso cref="CheckedToInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long UncheckedToInt64() {
-            return unchecked((long)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="long" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt64"/>
-        /// <seealso cref="UncheckedToInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long? CheckedToInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (tmp < long.MinValue ||
-                tmp > long.MaxValue) {
-                return null;
-            }
-
-            return (long)tmp;
+        public static explicit operator long(I68F60 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong StrictToUInt64() {
-            return checked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(I68F60 v) {
+            return (ulong)(v.Bits / OneRepr);
+        }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(I68F60 v) {
+            return (Int128)(v.Bits / OneRepr);
         }
 
         /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
         /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong UncheckedToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator UInt128(I68F60 v) {
+            return (UInt128)(v.Bits / OneRepr);
         }
 
-        /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="UncheckedToUInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong? CheckedToUInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > ulong.MaxValue) {
-                return null;
-            }
-
-            return (ulong)tmp;
-        }
-
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/I8F120.gen.cs
+++ b/Intar/I8F120.gen.cs
@@ -391,134 +391,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
-
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() {
-            return unchecked((int)(Bits / OneRepr));
+        public static explicit operator int(I8F120 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(I8F120 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(I8F120 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong StrictToUInt64() {
-            return checked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(I8F120 v) {
+            return (ulong)(v.Bits / OneRepr);
+        }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(I8F120 v) {
+            return (Int128)(v.Bits / OneRepr);
         }
 
         /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
         /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong UncheckedToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator UInt128(I8F120 v) {
+            return (UInt128)(v.Bits / OneRepr);
         }
 
-        /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="UncheckedToUInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong? CheckedToUInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号ありで、相手が符号なしの場合、
-            // 自身が 0 未満、または
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp < 0) {
-                return null;
-            } else if ((UInt128)tmp > ulong.MaxValue) {
-                return null;
-            }
-
-            return (ulong)tmp;
-        }
-
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/U17F15.gen.cs
+++ b/Intar/U17F15.gen.cs
@@ -414,44 +414,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
-
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() {
-            return unchecked((int)(Bits / OneRepr));
+        public static explicit operator int(U17F15 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint ToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
+        public static explicit operator uint(U17F15 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(U17F15 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong ToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(U17F15 v) {
+            return (ulong)(v.Bits / OneRepr);
         }
 
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(U17F15 v) {
+            return (Int128)(v.Bits / OneRepr);
+        }
+
+        /// <summary>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(U17F15 v) {
+            return (UInt128)(v.Bits / OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/U2F30.gen.cs
+++ b/Intar/U2F30.gen.cs
@@ -414,44 +414,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
-
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() {
-            return unchecked((int)(Bits / OneRepr));
+        public static explicit operator int(U2F30 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint ToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
+        public static explicit operator uint(U2F30 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(U2F30 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong ToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(U2F30 v) {
+            return (ulong)(v.Bits / OneRepr);
         }
 
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(U2F30 v) {
+            return (Int128)(v.Bits / OneRepr);
+        }
+
+        /// <summary>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(U2F30 v) {
+            return (UInt128)(v.Bits / OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/U2F62.gen.cs
+++ b/Intar/U2F62.gen.cs
@@ -415,44 +415,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
-
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() {
-            return unchecked((int)(Bits / OneRepr));
+        public static explicit operator int(U2F62 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint ToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
+        public static explicit operator uint(U2F62 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(U2F62 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong ToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(U2F62 v) {
+            return (ulong)(v.Bits / OneRepr);
         }
 
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(U2F62 v) {
+            return (Int128)(v.Bits / OneRepr);
+        }
+
+        /// <summary>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(U2F62 v) {
+            return (UInt128)(v.Bits / OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/U33F31.gen.cs
+++ b/Intar/U33F31.gen.cs
@@ -415,129 +415,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
 
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
-
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int StrictToInt32() {
-            return checked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int UncheckedToInt32() {
-            return unchecked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="UncheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int? CheckedToInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp > int.MaxValue) {
-                return null;
-            }
-
-            return (int)tmp;
+        public static explicit operator int(U33F31 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (tmp < uint.MinValue ||
-                tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(U33F31 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(U33F31 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong ToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(U33F31 v) {
+            return (ulong)(v.Bits / OneRepr);
         }
 
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(U33F31 v) {
+            return (Int128)(v.Bits / OneRepr);
+        }
+
+        /// <summary>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(U33F31 v) {
+            return (UInt128)(v.Bits / OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/U34F30.gen.cs
+++ b/Intar/U34F30.gen.cs
@@ -429,129 +429,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
 
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
-
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int StrictToInt32() {
-            return checked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int UncheckedToInt32() {
-            return unchecked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="UncheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int? CheckedToInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp > int.MaxValue) {
-                return null;
-            }
-
-            return (int)tmp;
+        public static explicit operator int(U34F30 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (tmp < uint.MinValue ||
-                tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(U34F30 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(U34F30 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong ToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(U34F30 v) {
+            return (ulong)(v.Bits / OneRepr);
         }
 
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(U34F30 v) {
+            return (Int128)(v.Bits / OneRepr);
+        }
+
+        /// <summary>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(U34F30 v) {
+            return (UInt128)(v.Bits / OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/U4F60.gen.cs
+++ b/Intar/U4F60.gen.cs
@@ -429,44 +429,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
-
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() {
-            return unchecked((int)(Bits / OneRepr));
+        public static explicit operator int(U4F60 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint ToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
+        public static explicit operator uint(U4F60 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(U4F60 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong ToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(U4F60 v) {
+            return (ulong)(v.Bits / OneRepr);
         }
 
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(U4F60 v) {
+            return (Int128)(v.Bits / OneRepr);
+        }
+
+        /// <summary>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(U4F60 v) {
+            return (UInt128)(v.Bits / OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/U68F60.gen.cs
+++ b/Intar/U68F60.gen.cs
@@ -375,214 +375,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
 
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
-
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int StrictToInt32() {
-            return checked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="CheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int UncheckedToInt32() {
-            return unchecked((int)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="int" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt32"/>
-        /// <seealso cref="UncheckedToInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int? CheckedToInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp > int.MaxValue) {
-                return null;
-            }
-
-            return (int)tmp;
+        public static explicit operator int(U68F60 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint StrictToUInt32() {
-            return checked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="CheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint UncheckedToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="uint" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt32"/>
-        /// <seealso cref="UncheckedToUInt32"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint? CheckedToUInt32() {
-            var tmp = Bits / OneRepr;
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (tmp < uint.MinValue ||
-                tmp > uint.MaxValue) {
-                return null;
-            }
-
-            return (uint)tmp;
+        public static explicit operator uint(U68F60 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToInt64"/>
-        /// <seealso cref="CheckedToInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long StrictToInt64() {
-            return checked((long)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="long" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt64"/>
-        /// <seealso cref="CheckedToInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long UncheckedToInt64() {
-            return unchecked((long)(Bits / OneRepr));
-        }
-
-        /// <summary>
-        /// <para><see cref="long" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToInt64"/>
-        /// <seealso cref="UncheckedToInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long? CheckedToInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身が符号なしで、相手が符号ありの場合、
-            // 自身が相手の最大値よりも大きければ null
-            if (tmp > long.MaxValue) {
-                return null;
-            }
-
-            return (long)tmp;
+        public static explicit operator long(U68F60 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="WARNING alert alert-info">
-        /// <h5>Warning</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは例外を送出します。</para>
-        /// </div>
         /// </summary>
-        /// <seealso cref="UncheckedToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong StrictToUInt64() {
-            return checked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(U68F60 v) {
+            return (ulong)(v.Bits / OneRepr);
+        }
+
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(U68F60 v) {
+            return (Int128)(v.Bits / OneRepr);
         }
 
         /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="CAUTION alert alert-info">
-        /// <h5>Caution</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは誤った値を返します。</para>
-        /// </div>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
         /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="CheckedToUInt64"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong UncheckedToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator UInt128(U68F60 v) {
+            return (UInt128)(v.Bits / OneRepr);
         }
 
-        /// <summary>
-        /// <para><see cref="ulong" /> への変換を行います。</para>
-        /// <div class="NOTE alert alert-info">
-        /// <h5>Note</h5>
-        /// <para>結果が表現できる値の範囲外の場合、このメソッドは <c>null</c> を返します。</para>
-        /// </div>
-        /// </summary>
-        /// <seealso cref="StrictToUInt64"/>
-        /// <seealso cref="UncheckedToUInt64"/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong? CheckedToUInt64() {
-            var tmp = Bits / OneRepr;
-
-            // 自身と相手の符号が同じ場合、
-            // 暗黙に大きい方の型にキャストされる。
-            if (tmp < ulong.MinValue ||
-                tmp > ulong.MaxValue) {
-                return null;
-            }
-
-            return (ulong)tmp;
-        }
-
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number

--- a/Intar/U8F120.gen.cs
+++ b/Intar/U8F120.gen.cs
@@ -375,44 +375,59 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Convert to integer
-
-        // 整数への変換で小数点以下の精度が失われるのは自明なので
-        // わざわざ明記することはしない。
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() {
-            return unchecked((int)(Bits / OneRepr));
+        public static explicit operator int(U8F120 v) {
+            return (int)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="uint" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint ToUInt32() {
-            return unchecked((uint)(Bits / OneRepr));
+        public static explicit operator uint(U8F120 v) {
+            return (uint)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="long" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ToInt64() {
-            return unchecked((long)(Bits / OneRepr));
+        public static explicit operator long(U8F120 v) {
+            return (long)(v.Bits / OneRepr);
         }
 
         /// <summary>
         /// <para><see cref="ulong" /> への変換を行います。</para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong ToUInt64() {
-            return unchecked((ulong)(Bits / OneRepr));
+        public static explicit operator ulong(U8F120 v) {
+            return (ulong)(v.Bits / OneRepr);
         }
 
+#if NET7_0_OR_GREATER
+
+        /// <summary>
+        /// <para><see cref="Int128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(U8F120 v) {
+            return (Int128)(v.Bits / OneRepr);
+        }
+
+        /// <summary>
+        /// <para><see cref="UInt128" /> への変換を行います。</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(U8F120 v) {
+            return (UInt128)(v.Bits / OneRepr);
+        }
+
+#endif // NET7_0_OR_GREATER
         #endregion
 
         #region Convert to floating-point number


### PR DESCRIPTION
専用の静的メソッド
To, StrictTo, CheckedTo, UncheckedTo を廃止し,
一般的な C# の変換演算子のインタフェースに変更した.

これは, 実際のユースケースではオーバーフローが発生することは稀であり,
それらを厳密に取り扱うためのメソッドは過剰実装であるという判断に基づく.