### PR TITLE
固定小数点数から浮動小数点数への変換を簡略化

### DIFF
--- a/.generator/templates/AffineTransform.cs
+++ b/.generator/templates/AffineTransform.cs
@@ -70,11 +70,11 @@ namespace {{ namespace }} {
             return new System.Numerics.Matrix4x4(
                 {%- for i in range(end=dim) %}
                 {% for j in range(end=dim) -%}
-                a.RotationScale.C{{ i }}.{{ components[j] }}.LossyToSingle(), {# #}
+                (float)a.RotationScale.C{{ i }}.{{ components[j] }}, {# #}
                 {%- endfor -%}0,
                 {%- endfor %}
                 {% for i in range(end=dim) -%}
-                a.Translation.{{ components[i] }}.LossyToSingle(), {# #}
+                (float)a.Translation.{{ components[i] }}, {# #}
                 {%- endfor %}1
             );
         }
@@ -86,12 +86,12 @@ namespace {{ namespace }} {
                 {%- for i in range(end=dim) %}
                 new UnityEngine.Vector4(
                 {%- for j in range(end=dim) -%}
-                a.RotationScale.C{{ i }}.{{ components[j] }}.LossyToSingle(), {# #}
+                (float)a.RotationScale.C{{ i }}.{{ components[j] }}, {# #}
                 {%- endfor -%}0),
                 {%- endfor %}
                 new UnityEngine.Vector4(
                 {%- for i in range(end=dim) -%}
-                a.Translation.{{ components[i] }}.LossyToSingle(), {# #}
+                (float)a.Translation.{{ components[i] }}, {# #}
                 {%- endfor %}1)
             );
         }
@@ -103,9 +103,9 @@ namespace {{ namespace }} {
             return new Unity.Mathematics.float4x4(
                 {%- for i in range(end=dim) %}
                 {% for j in range(end=dim) -%}
-                a.RotationScale.C{{ j }}.{{ components[i] }}.LossyToSingle(), {# #}
+                (float)a.RotationScale.C{{ j }}.{{ components[i] }}, {# #}
                 {%- endfor -%}
-                a.Translation.{{ components[i] }}.LossyToSingle(),
+                (float)a.Translation.{{ components[i] }},
                 {%- endfor %}
                 0, 0, 0, 1
             );

--- a/.generator/templates/Fixed.cs
+++ b/.generator/templates/Fixed.cs
@@ -178,9 +178,7 @@ namespace {{ namespace }} {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => {% if
-            int_nbits + frac_nbits > 32
-        %}Lossy{% endif %}ToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -195,9 +193,7 @@ namespace {{ namespace }} {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return {% if
-                int_nbits + frac_nbits > 32
-            %}Lossy{% endif %}ToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -472,7 +468,6 @@ namespace {{ namespace }} {
         {%- endfor %}
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -495,7 +490,6 @@ namespace {{ namespace }} {
         {%- endfor %}
 
         #endregion
-
         #region Conversion from fixed-point number
 
         {%- for s in [true, false] %}
@@ -533,7 +527,7 @@ namespace {{ namespace }} {
         {%- endfor %}
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
         {%- for bits in [32, 64, 128] %}
         {%- if bits > 64 %}
 
@@ -556,25 +550,16 @@ namespace {{ namespace }} {
         {%- endif %}
         {%- endfor %}
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
-{# 改行 #}
-
-        {#- 浮動小数点数型への変換 #}
         {%- for bits in [32, 64] %}
         {%- if   bits == 32 %}{% set t='float'  %}
         {%- elif bits == 64 %}{% set t='double' %}{% endif %}
 
-        {#- 相手のビット数が自身以下の場合、精度を失う。 #}
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public {{ t }} {% if
-            bits <= int_nbits + frac_nbits
-        %}Lossy{% endif %}To{% if
-            bits == 32 %}Single{% elif
-            bits == 64 %}Double{% endif %}() => ({{ t }})Bits / ({{ t }})OneRepr;
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator {{ t }}({{ self_type }} v) => ({{ t }})v.Bits / ({{ t }})OneRepr;
         {%- endfor %}
 
         #endregion

--- a/.generator/templates/FixedDrawer.cs
+++ b/.generator/templates/FixedDrawer.cs
@@ -9,6 +9,12 @@ namespace {{ namespace }}.Editor {
     [CustomPropertyDrawer(typeof({{ type }}))]
     public class {{ type }}Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float){{ type }}.MinValue;
+            var max = (float){{ type }}.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -25,10 +31,7 @@ namespace {{ namespace }}.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                {{ type }}.MinValue.LossyToSingle(),
-                {{ type }}.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= {{ type }}.OneRepr;

--- a/.generator/templates/Matrix.cs
+++ b/.generator/templates/Matrix.cs
@@ -179,12 +179,12 @@ namespace {{ namespace }} {
                 {%- for i in range(end=3) %}
                 new UnityEngine.Vector4(
                 {%- for j in range(end=3) -%}
-                a.C{{ j }}.{{ components[i] }}.LossyToSingle(), {# #}
+                (float)a.C{{ j }}.{{ components[i] }}, {# #}
                 {%- endfor -%}0),
                 {%- endfor %}
                 new UnityEngine.Vector4(
                 {%- for i in range(end=3) -%}
-                a.C3.{{ components[i] }}.LossyToSingle(), {# #}
+                (float)a.C3.{{ components[i] }}, {# #}
                 {%- endfor %}1)
             );
         }
@@ -196,7 +196,7 @@ namespace {{ namespace }} {
             return new Unity.Mathematics.float{{ rows }}x{{ cols }}(
                 {%- for i in range(end=rows) %}
                 {% for j in range(end=cols) -%}
-                a.C{{ j }}.{{ components[i] }}.LossyToSingle(){% if not loop.last %}, {% endif %}
+                (float)a.C{{ j }}.{{ components[i] }}{% if not loop.last %}, {% endif %}
                 {%- endfor %}
                 {%- if not loop.last %},{% endif %}
                 {%- endfor %}

--- a/.generator/templates/MatrixTest.cs
+++ b/.generator/templates/MatrixTest.cs
@@ -21,7 +21,7 @@ namespace {{ namespace }}.Tests {
             {%- for c in range(end=4) %}
             d = Math.Max(d, Math.Abs(e.M{{ r + 1 }}{{ c + 1 }}
             {%- if   r == 3 and c == 3 %} - 1
-            {%- elif r != 3 and c != 3 %} - a.C{{ c }}.{{ components[r] }}.LossyToSingle(){%- endif %}));
+            {%- elif r != 3 and c != 3 %} - (float)a.C{{ c }}.{{ components[r] }}{%- endif %}));
             {%- endfor %}
             {%- endfor %}
             return d;
@@ -35,7 +35,7 @@ namespace {{ namespace }}.Tests {
             {%- for c in range(end=4) %}
             d = Math.Max(d, Math.Abs(e.m{{ r }}{{ c }}
             {%- if   r == 3 and c == 3 %} - 1
-            {%- elif r != 3 and c != 3 %} - a.C{{ c }}.{{ components[r] }}.LossyToSingle()
+            {%- elif r != 3 and c != 3 %} - (float)a.C{{ c }}.{{ components[r] }}
             {%- endif %}));
             {%- endfor %}
             {%- endfor %}
@@ -48,7 +48,7 @@ namespace {{ namespace }}.Tests {
             var d = 0.0;
             {%- for r in range(end=3) %}
             {%- for c in range(end=3) %}
-            d = Math.Max(d, Math.Abs(e.c{{ c }}.{{ components[r]|lower }} - a.C{{ c }}.{{ components[r] }}.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.c{{ c }}.{{ components[r]|lower }} - (float)a.C{{ c }}.{{ components[r] }}));
             {%- endfor %}
             {%- endfor %}
             return d;
@@ -120,15 +120,15 @@ namespace {{ namespace }}.Tests {
 
                 {
                     var mf1 = new System.Numerics.Matrix4x4(
-                        m1.C0.X.LossyToSingle(), m1.C1.X.LossyToSingle(), m1.C2.X.LossyToSingle(), 0,
-                        m1.C0.Y.LossyToSingle(), m1.C1.Y.LossyToSingle(), m1.C2.Y.LossyToSingle(), 0,
-                        m1.C0.Z.LossyToSingle(), m1.C1.Z.LossyToSingle(), m1.C2.Z.LossyToSingle(), 0,
+                        (float)m1.C0.X, (float)m1.C1.X, (float)m1.C2.X, 0,
+                        (float)m1.C0.Y, (float)m1.C1.Y, (float)m1.C2.Y, 0,
+                        (float)m1.C0.Z, (float)m1.C1.Z, (float)m1.C2.Z, 0,
                         0, 0, 0, 1
                     );
                     var mf2 = new System.Numerics.Matrix4x4(
-                        m2.C0.X.LossyToSingle(), m2.C1.X.LossyToSingle(), m2.C2.X.LossyToSingle(), 0,
-                        m2.C0.Y.LossyToSingle(), m2.C1.Y.LossyToSingle(), m2.C2.Y.LossyToSingle(), 0,
-                        m2.C0.Z.LossyToSingle(), m2.C1.Z.LossyToSingle(), m2.C2.Z.LossyToSingle(), 0,
+                        (float)m2.C0.X, (float)m2.C1.X, (float)m2.C2.X, 0,
+                        (float)m2.C0.Y, (float)m2.C1.Y, (float)m2.C2.Y, 0,
+                        (float)m2.C0.Z, (float)m2.C1.Z, (float)m2.C2.Z, 0,
                         0, 0, 0, 1
                     );
                     var e = mf1 * mf2;
@@ -196,7 +196,7 @@ namespace {{ namespace }}.Tests {
             var dm3 = 0.0;
             for (var i = 0; i < 32768; i++) {
                 var angle = Utility.RandomI17F15(ref rng);
-                var rad = (float)(angle.LossyToSingle() * Math.PI / 2);
+                var rad = (float)angle * (float)(Math.PI / 2);
                 var a = Matrix3x3I2F30.Rotate{{ a|upper }}P5(angle);
 
                 {
@@ -208,7 +208,7 @@ namespace {{ namespace }}.Tests {
 
 #if UNITY_5_3_OR_NEWER
                 {
-                    var deg = (float)(angle.LossyToSingle() * 90);
+                    var deg = (float)angle * 90;
                     var e = UnityEngine.Matrix4x4.Rotate(UnityEngine.Quaternion.Euler(
                         {%- for i in range(end=3) %}
                         {%- if index == i %}deg{% else %}0{% endif %}
@@ -260,8 +260,8 @@ namespace {{ namespace }}.Tests {
                         {% if loop.first %}=
                         {%- else %}*
                         {%- endif %} System.Numerics.Matrix4x4.CreateRotation
-                        {{- i | upper }}(angles.
-                        {{- i | upper }}.LossyToSingle() * (float)Math.PI / 2)
+                        {{- i | upper }}((float)angles.
+                        {{- i | upper }} * (float)(Math.PI / 2))
                     {%- endfor %};
                     var d = Delta(System.Numerics.Matrix4x4.Transpose(e), a);
                     if (d > 0.1) { Assert.Fail(); };
@@ -330,7 +330,7 @@ namespace {{ namespace }}.Tests {
                     var e = System.Numerics.Matrix4x4.Transpose(
                         System.Numerics.Matrix4x4.CreateFromAxisAngle(
                             (System.Numerics.Vector3)axis,
-                            (float)(angle.LossyToSingle() * Math.PI / 2)
+                            (float)angle * (float)(Math.PI / 2)
                         )
                     );
                     var d = Delta(e, a);
@@ -342,7 +342,7 @@ namespace {{ namespace }}.Tests {
                 {
                     var e = UnityEngine.Matrix4x4.Rotate(
                         UnityEngine.Quaternion.AngleAxis(
-                            (float)(angle.LossyToSingle() * 90),
+                            (float)angle * 90,
                             (UnityEngine.Vector3)axis
                         )
                     );
@@ -356,7 +356,7 @@ namespace {{ namespace }}.Tests {
                 {
                     var e = Unity.Mathematics.float3x3.AxisAngle(
                         (Unity.Mathematics.float3)axis,
-                        (float)(angle.LossyToSingle() * Math.PI / 2)
+                        (float)angle * (float)(Math.PI / 2)
                     );
                     var d = Delta(e, a);
                     if (d > 0.1) { Assert.Fail(); };

--- a/.generator/templates/Quaternion.cs
+++ b/.generator/templates/Quaternion.cs
@@ -92,7 +92,7 @@ namespace {{ namespace }} {
         public static explicit operator System.Numerics.Quaternion({{ quaternion }} q) {
             return new System.Numerics.Quaternion(
                 {%- for c in components %}
-                q.{{ c }}.LossyToSingle(){% if not loop.last %},{% endif %}
+                (float)q.{{ c }}{% if not loop.last %},{% endif %}
                 {%- endfor %}
             );
         }
@@ -101,7 +101,7 @@ namespace {{ namespace }} {
         public static explicit operator UnityEngine.Quaternion({{ quaternion }} q) {
             return new UnityEngine.Quaternion(
                 {%- for c in components %}
-                q.{{ c }}.LossyToSingle(){% if not loop.last %},{% endif %}
+                (float)q.{{ c }}{% if not loop.last %},{% endif %}
                 {%- endfor %}
             );
         }
@@ -111,7 +111,7 @@ namespace {{ namespace }} {
         public static explicit operator Unity.Mathematics.quaternion({{ quaternion }} q) {
             return new Unity.Mathematics.quaternion(
                 {%- for c in components %}
-                q.{{ c }}.LossyToSingle(){% if not loop.last %},{% endif %}
+                (float)q.{{ c }}{% if not loop.last %},{% endif %}
                 {%- endfor %}
             );
         }

--- a/.generator/templates/VectorDrawer.cs
+++ b/.generator/templates/VectorDrawer.cs
@@ -12,8 +12,8 @@ namespace {{ namespace }}.Editor {
     public class {{ type }}Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = {{ component }}.MinValue.LossyToSingle();
-            var max = {{ component }}.MaxValue.LossyToSingle();
+            var min = (float){{ component }}.MinValue;
+            var max = (float){{ component }}.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/I17F15Drawer.gen.cs
+++ b/Intar.Editor/I17F15Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(I17F15))]
     public class I17F15Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)I17F15.MinValue;
+            var max = (float)I17F15.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                I17F15.MinValue.LossyToSingle(),
-                I17F15.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= I17F15.OneRepr;

--- a/Intar.Editor/I2F30Drawer.gen.cs
+++ b/Intar.Editor/I2F30Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(I2F30))]
     public class I2F30Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)I2F30.MinValue;
+            var max = (float)I2F30.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                I2F30.MinValue.LossyToSingle(),
-                I2F30.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= I2F30.OneRepr;

--- a/Intar.Editor/I2F62Drawer.gen.cs
+++ b/Intar.Editor/I2F62Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(I2F62))]
     public class I2F62Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)I2F62.MinValue;
+            var max = (float)I2F62.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                I2F62.MinValue.LossyToSingle(),
-                I2F62.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= I2F62.OneRepr;

--- a/Intar.Editor/I33F31Drawer.gen.cs
+++ b/Intar.Editor/I33F31Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(I33F31))]
     public class I33F31Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)I33F31.MinValue;
+            var max = (float)I33F31.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                I33F31.MinValue.LossyToSingle(),
-                I33F31.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= I33F31.OneRepr;

--- a/Intar.Editor/I34F30Drawer.gen.cs
+++ b/Intar.Editor/I34F30Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(I34F30))]
     public class I34F30Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)I34F30.MinValue;
+            var max = (float)I34F30.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                I34F30.MinValue.LossyToSingle(),
-                I34F30.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= I34F30.OneRepr;

--- a/Intar.Editor/I4F60Drawer.gen.cs
+++ b/Intar.Editor/I4F60Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(I4F60))]
     public class I4F60Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)I4F60.MinValue;
+            var max = (float)I4F60.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                I4F60.MinValue.LossyToSingle(),
-                I4F60.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= I4F60.OneRepr;

--- a/Intar.Editor/U17F15Drawer.gen.cs
+++ b/Intar.Editor/U17F15Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(U17F15))]
     public class U17F15Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)U17F15.MinValue;
+            var max = (float)U17F15.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                U17F15.MinValue.LossyToSingle(),
-                U17F15.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= U17F15.OneRepr;

--- a/Intar.Editor/U2F30Drawer.gen.cs
+++ b/Intar.Editor/U2F30Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(U2F30))]
     public class U2F30Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)U2F30.MinValue;
+            var max = (float)U2F30.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                U2F30.MinValue.LossyToSingle(),
-                U2F30.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= U2F30.OneRepr;

--- a/Intar.Editor/U2F62Drawer.gen.cs
+++ b/Intar.Editor/U2F62Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(U2F62))]
     public class U2F62Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)U2F62.MinValue;
+            var max = (float)U2F62.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                U2F62.MinValue.LossyToSingle(),
-                U2F62.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= U2F62.OneRepr;

--- a/Intar.Editor/U33F31Drawer.gen.cs
+++ b/Intar.Editor/U33F31Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(U33F31))]
     public class U33F31Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)U33F31.MinValue;
+            var max = (float)U33F31.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                U33F31.MinValue.LossyToSingle(),
-                U33F31.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= U33F31.OneRepr;

--- a/Intar.Editor/U34F30Drawer.gen.cs
+++ b/Intar.Editor/U34F30Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(U34F30))]
     public class U34F30Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)U34F30.MinValue;
+            var max = (float)U34F30.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                U34F30.MinValue.LossyToSingle(),
-                U34F30.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= U34F30.OneRepr;

--- a/Intar.Editor/U4F60Drawer.gen.cs
+++ b/Intar.Editor/U4F60Drawer.gen.cs
@@ -5,6 +5,12 @@ namespace Intar.Editor {
     [CustomPropertyDrawer(typeof(U4F60))]
     public class U4F60Drawer : PropertyDrawer {
         float? cache;
+        /// フィールドに表示する値を最大値・最小値で制限する
+        static float Clamp(float value) {
+            var min = (float)U4F60.MinValue;
+            var max = (float)U4F60.MaxValue;
+            return Mathf.Clamp(value, min, max);
+        }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that
             // prefab override logic works on the entire property.
@@ -21,10 +27,7 @@ namespace Intar.Editor {
             value = EditorGUI.FloatField(position, label, value);
 
             // 値を正規化してキャッシュを更新
-            cache = Mathf.Clamp(
-                value,
-                U4F60.MinValue.LossyToSingle(),
-                U4F60.MaxValue.LossyToSingle());
+            cache = Clamp(value);
 
             if (EditorGUI.EndChangeCheck()) {
                 value *= U4F60.OneRepr;

--- a/Intar.Editor/Vector2I17F15Drawer.gen.cs
+++ b/Intar.Editor/Vector2I17F15Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector2I17F15Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I17F15.MinValue.LossyToSingle();
-            var max = I17F15.MaxValue.LossyToSingle();
+            var min = (float)I17F15.MinValue;
+            var max = (float)I17F15.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector2I2F30Drawer.gen.cs
+++ b/Intar.Editor/Vector2I2F30Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector2I2F30Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I2F30.MinValue.LossyToSingle();
-            var max = I2F30.MaxValue.LossyToSingle();
+            var min = (float)I2F30.MinValue;
+            var max = (float)I2F30.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector2I34F30Drawer.gen.cs
+++ b/Intar.Editor/Vector2I34F30Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector2I34F30Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I34F30.MinValue.LossyToSingle();
-            var max = I34F30.MaxValue.LossyToSingle();
+            var min = (float)I34F30.MinValue;
+            var max = (float)I34F30.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector2I4F60Drawer.gen.cs
+++ b/Intar.Editor/Vector2I4F60Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector2I4F60Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I4F60.MinValue.LossyToSingle();
-            var max = I4F60.MaxValue.LossyToSingle();
+            var min = (float)I4F60.MinValue;
+            var max = (float)I4F60.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector3I17F15Drawer.gen.cs
+++ b/Intar.Editor/Vector3I17F15Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector3I17F15Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I17F15.MinValue.LossyToSingle();
-            var max = I17F15.MaxValue.LossyToSingle();
+            var min = (float)I17F15.MinValue;
+            var max = (float)I17F15.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector3I2F30Drawer.gen.cs
+++ b/Intar.Editor/Vector3I2F30Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector3I2F30Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I2F30.MinValue.LossyToSingle();
-            var max = I2F30.MaxValue.LossyToSingle();
+            var min = (float)I2F30.MinValue;
+            var max = (float)I2F30.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector3I34F30Drawer.gen.cs
+++ b/Intar.Editor/Vector3I34F30Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector3I34F30Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I34F30.MinValue.LossyToSingle();
-            var max = I34F30.MaxValue.LossyToSingle();
+            var min = (float)I34F30.MinValue;
+            var max = (float)I34F30.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector3I4F60Drawer.gen.cs
+++ b/Intar.Editor/Vector3I4F60Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector3I4F60Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I4F60.MinValue.LossyToSingle();
-            var max = I4F60.MaxValue.LossyToSingle();
+            var min = (float)I4F60.MinValue;
+            var max = (float)I4F60.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector4I17F15Drawer.gen.cs
+++ b/Intar.Editor/Vector4I17F15Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector4I17F15Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I17F15.MinValue.LossyToSingle();
-            var max = I17F15.MaxValue.LossyToSingle();
+            var min = (float)I17F15.MinValue;
+            var max = (float)I17F15.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector4I2F30Drawer.gen.cs
+++ b/Intar.Editor/Vector4I2F30Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector4I2F30Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I2F30.MinValue.LossyToSingle();
-            var max = I2F30.MaxValue.LossyToSingle();
+            var min = (float)I2F30.MinValue;
+            var max = (float)I2F30.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector4I34F30Drawer.gen.cs
+++ b/Intar.Editor/Vector4I34F30Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector4I34F30Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I34F30.MinValue.LossyToSingle();
-            var max = I34F30.MaxValue.LossyToSingle();
+            var min = (float)I34F30.MinValue;
+            var max = (float)I34F30.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Editor/Vector4I4F60Drawer.gen.cs
+++ b/Intar.Editor/Vector4I4F60Drawer.gen.cs
@@ -6,8 +6,8 @@ namespace Intar.Editor {
     public class Vector4I4F60Drawer : PropertyDrawer {
         /// フィールドに表示する値を最大値・最小値で制限する
         static float Clamp(float value) {
-            var min = I4F60.MinValue.LossyToSingle();
-            var max = I4F60.MaxValue.LossyToSingle();
+            var min = (float)I4F60.MinValue;
+            var max = (float)I4F60.MaxValue;
             return Mathf.Clamp(value, min, max);
         }
 

--- a/Intar.Tests/AffineTransformTest.cs
+++ b/Intar.Tests/AffineTransformTest.cs
@@ -9,21 +9,21 @@ namespace Intar.Tests {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Delta(System.Numerics.Matrix4x4 e, AffineTransform3I17F15 a) {
             var d = 0.0;
-            d = Math.Max(d, Math.Abs(e.M11 - a.RotationScale.C0.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M12 - a.RotationScale.C0.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M13 - a.RotationScale.C0.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.M11 - (float)a.RotationScale.C0.X));
+            d = Math.Max(d, Math.Abs(e.M12 - (float)a.RotationScale.C0.Y));
+            d = Math.Max(d, Math.Abs(e.M13 - (float)a.RotationScale.C0.Z));
             d = Math.Max(d, Math.Abs(e.M14));
-            d = Math.Max(d, Math.Abs(e.M21 - a.RotationScale.C1.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M22 - a.RotationScale.C1.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M23 - a.RotationScale.C1.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.M21 - (float)a.RotationScale.C1.X));
+            d = Math.Max(d, Math.Abs(e.M22 - (float)a.RotationScale.C1.Y));
+            d = Math.Max(d, Math.Abs(e.M23 - (float)a.RotationScale.C1.Z));
             d = Math.Max(d, Math.Abs(e.M24));
-            d = Math.Max(d, Math.Abs(e.M31 - a.RotationScale.C2.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M32 - a.RotationScale.C2.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M33 - a.RotationScale.C2.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.M31 - (float)a.RotationScale.C2.X));
+            d = Math.Max(d, Math.Abs(e.M32 - (float)a.RotationScale.C2.Y));
+            d = Math.Max(d, Math.Abs(e.M33 - (float)a.RotationScale.C2.Z));
             d = Math.Max(d, Math.Abs(e.M34));
-            d = Math.Max(d, Math.Abs(e.M41 - a.Translation.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M42 - a.Translation.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M43 - a.Translation.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.M41 - (float)a.Translation.X));
+            d = Math.Max(d, Math.Abs(e.M42 - (float)a.Translation.Y));
+            d = Math.Max(d, Math.Abs(e.M43 - (float)a.Translation.Z));
             d = Math.Max(d, Math.Abs(e.M44 - 1.0));
             return d;
         }
@@ -32,21 +32,21 @@ namespace Intar.Tests {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Delta(UnityEngine.Matrix4x4 e, AffineTransform3I17F15 a) {
             var d = 0.0;
-            d = Math.Max(d, Math.Abs(e.m00 - a.RotationScale.C0.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m10 - a.RotationScale.C0.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m20 - a.RotationScale.C0.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.m00 - (float)a.RotationScale.C0.X));
+            d = Math.Max(d, Math.Abs(e.m10 - (float)a.RotationScale.C0.Y));
+            d = Math.Max(d, Math.Abs(e.m20 - (float)a.RotationScale.C0.Z));
             d = Math.Max(d, Math.Abs(e.m30));
-            d = Math.Max(d, Math.Abs(e.m01 - a.RotationScale.C1.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m11 - a.RotationScale.C1.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m21 - a.RotationScale.C1.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.m01 - (float)a.RotationScale.C1.X));
+            d = Math.Max(d, Math.Abs(e.m11 - (float)a.RotationScale.C1.Y));
+            d = Math.Max(d, Math.Abs(e.m21 - (float)a.RotationScale.C1.Z));
             d = Math.Max(d, Math.Abs(e.m31));
-            d = Math.Max(d, Math.Abs(e.m02 - a.RotationScale.C2.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m12 - a.RotationScale.C2.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m22 - a.RotationScale.C2.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.m02 - (float)a.RotationScale.C2.X));
+            d = Math.Max(d, Math.Abs(e.m12 - (float)a.RotationScale.C2.Y));
+            d = Math.Max(d, Math.Abs(e.m22 - (float)a.RotationScale.C2.Z));
             d = Math.Max(d, Math.Abs(e.m32));
-            d = Math.Max(d, Math.Abs(e.m03 - a.Translation.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m13 - a.Translation.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m23 - a.Translation.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.m03 - (float)a.Translation.X));
+            d = Math.Max(d, Math.Abs(e.m13 - (float)a.Translation.Y));
+            d = Math.Max(d, Math.Abs(e.m23 - (float)a.Translation.Z));
             d = Math.Max(d, Math.Abs(e.m33 - 1.0));
             return d;
         }
@@ -56,21 +56,21 @@ namespace Intar.Tests {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Delta(Unity.Mathematics.float4x4 e, AffineTransform3I17F15 a) {
             var d = 0.0;
-            d = Math.Max(d, Math.Abs(e.c0.x - a.RotationScale.C0.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c0.y - a.RotationScale.C0.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c0.z - a.RotationScale.C0.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.c0.x - (float)a.RotationScale.C0.X));
+            d = Math.Max(d, Math.Abs(e.c0.y - (float)a.RotationScale.C0.Y));
+            d = Math.Max(d, Math.Abs(e.c0.z - (float)a.RotationScale.C0.Z));
             d = Math.Max(d, Math.Abs(e.c0.w));
-            d = Math.Max(d, Math.Abs(e.c1.x - a.RotationScale.C1.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c1.y - a.RotationScale.C1.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c1.z - a.RotationScale.C1.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.c1.x - (float)a.RotationScale.C1.X));
+            d = Math.Max(d, Math.Abs(e.c1.y - (float)a.RotationScale.C1.Y));
+            d = Math.Max(d, Math.Abs(e.c1.z - (float)a.RotationScale.C1.Z));
             d = Math.Max(d, Math.Abs(e.c1.w));
-            d = Math.Max(d, Math.Abs(e.c2.x - a.RotationScale.C2.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c2.y - a.RotationScale.C2.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c2.z - a.RotationScale.C2.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.c2.x - (float)a.RotationScale.C2.X));
+            d = Math.Max(d, Math.Abs(e.c2.y - (float)a.RotationScale.C2.Y));
+            d = Math.Max(d, Math.Abs(e.c2.z - (float)a.RotationScale.C2.Z));
             d = Math.Max(d, Math.Abs(e.c2.w));
-            d = Math.Max(d, Math.Abs(e.c3.x - a.Translation.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c3.y - a.Translation.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c3.z - a.Translation.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.c3.x - (float)a.Translation.X));
+            d = Math.Max(d, Math.Abs(e.c3.y - (float)a.Translation.Y));
+            d = Math.Max(d, Math.Abs(e.c3.z - (float)a.Translation.Z));
             d = Math.Max(d, Math.Abs(e.c3.w - 1.0));
             return d;
         }
@@ -252,9 +252,9 @@ namespace Intar.Tests {
                     var t = (System.Numerics.Matrix4x4)transform;
                     var p = (System.Numerics.Vector3)pos;
                     var e = System.Numerics.Vector3.Transform(p, t);
-                    var d1 = Math.Abs(e.X - a.X.LossyToSingle());
-                    var d2 = Math.Abs(e.Y - a.Y.LossyToSingle());
-                    var d3 = Math.Abs(e.Z - a.Z.LossyToSingle());
+                    var d1 = Math.Abs(e.X - (float)a.X);
+                    var d2 = Math.Abs(e.Y - (float)a.Y);
+                    var d3 = Math.Abs(e.Z - (float)a.Z);
                     var d = Math.Max(d1, Math.Max(d2, d3));
                     if (d > 0.1) { Assert.Fail($"e:{e}\n a:{a}"); }
                     dm1 = Math.Max(dm1, d);
@@ -264,14 +264,14 @@ namespace Intar.Tests {
                 {
                     var t = (UnityEngine.Matrix4x4)transform;
                     var p = new UnityEngine.Vector4(
-                        pos.X.LossyToSingle(),
-                        pos.Y.LossyToSingle(),
-                        pos.Z.LossyToSingle(),
+                        (float)pos.X,
+                        (float)pos.Y,
+                        (float)pos.Z,
                         1);
                     var e = t * p;
-                    var d1 = Math.Abs(e.x - a.X.LossyToSingle());
-                    var d2 = Math.Abs(e.y - a.Y.LossyToSingle());
-                    var d3 = Math.Abs(e.z - a.Z.LossyToSingle());
+                    var d1 = Math.Abs(e.x - (float)a.X);
+                    var d2 = Math.Abs(e.y - (float)a.Y);
+                    var d3 = Math.Abs(e.z - (float)a.Z);
                     var d = Math.Max(d1, Math.Max(d2, d3));
                     if (d > 0.1) { Assert.Fail($"e:{e}\n a:{a}"); }
                     dm2 = Math.Max(dm2, d);
@@ -283,9 +283,9 @@ namespace Intar.Tests {
                     var t = (Unity.Mathematics.float4x4)transform;
                     var p = (Unity.Mathematics.float3)pos;
                     var e = Unity.Mathematics.math.transform(t, p);
-                    var d1 = Math.Abs(e.x - a.X.LossyToSingle());
-                    var d2 = Math.Abs(e.y - a.Y.LossyToSingle());
-                    var d3 = Math.Abs(e.z - a.Z.LossyToSingle());
+                    var d1 = Math.Abs(e.x - (float)a.X);
+                    var d2 = Math.Abs(e.y - (float)a.Y);
+                    var d3 = Math.Abs(e.z - (float)a.Z);
                     var d = Math.Max(d1, Math.Max(d2, d3));
                     if (d > 0.1) { Assert.Fail($"e:{e}\n a:{a}"); }
                     dm3 = Math.Max(dm3, d);

--- a/Intar.Tests/MatrixTest.gen.cs
+++ b/Intar.Tests/MatrixTest.gen.cs
@@ -12,17 +12,17 @@ namespace Intar.Tests {
 
         public static double Delta(System.Numerics.Matrix4x4 e, Matrix3x3I17F15 a) {
             var d = 0.0;
-            d = Math.Max(d, Math.Abs(e.M11 - a.C0.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M12 - a.C1.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M13 - a.C2.X.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.M11 - (float)a.C0.X));
+            d = Math.Max(d, Math.Abs(e.M12 - (float)a.C1.X));
+            d = Math.Max(d, Math.Abs(e.M13 - (float)a.C2.X));
             d = Math.Max(d, Math.Abs(e.M14));
-            d = Math.Max(d, Math.Abs(e.M21 - a.C0.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M22 - a.C1.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M23 - a.C2.Y.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.M21 - (float)a.C0.Y));
+            d = Math.Max(d, Math.Abs(e.M22 - (float)a.C1.Y));
+            d = Math.Max(d, Math.Abs(e.M23 - (float)a.C2.Y));
             d = Math.Max(d, Math.Abs(e.M24));
-            d = Math.Max(d, Math.Abs(e.M31 - a.C0.Z.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M32 - a.C1.Z.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M33 - a.C2.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.M31 - (float)a.C0.Z));
+            d = Math.Max(d, Math.Abs(e.M32 - (float)a.C1.Z));
+            d = Math.Max(d, Math.Abs(e.M33 - (float)a.C2.Z));
             d = Math.Max(d, Math.Abs(e.M34));
             d = Math.Max(d, Math.Abs(e.M41));
             d = Math.Max(d, Math.Abs(e.M42));
@@ -33,17 +33,17 @@ namespace Intar.Tests {
 
         public static double Delta(System.Numerics.Matrix4x4 e, Matrix3x3I2F30 a) {
             var d = 0.0;
-            d = Math.Max(d, Math.Abs(e.M11 - a.C0.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M12 - a.C1.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M13 - a.C2.X.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.M11 - (float)a.C0.X));
+            d = Math.Max(d, Math.Abs(e.M12 - (float)a.C1.X));
+            d = Math.Max(d, Math.Abs(e.M13 - (float)a.C2.X));
             d = Math.Max(d, Math.Abs(e.M14));
-            d = Math.Max(d, Math.Abs(e.M21 - a.C0.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M22 - a.C1.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M23 - a.C2.Y.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.M21 - (float)a.C0.Y));
+            d = Math.Max(d, Math.Abs(e.M22 - (float)a.C1.Y));
+            d = Math.Max(d, Math.Abs(e.M23 - (float)a.C2.Y));
             d = Math.Max(d, Math.Abs(e.M24));
-            d = Math.Max(d, Math.Abs(e.M31 - a.C0.Z.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M32 - a.C1.Z.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.M33 - a.C2.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.M31 - (float)a.C0.Z));
+            d = Math.Max(d, Math.Abs(e.M32 - (float)a.C1.Z));
+            d = Math.Max(d, Math.Abs(e.M33 - (float)a.C2.Z));
             d = Math.Max(d, Math.Abs(e.M34));
             d = Math.Max(d, Math.Abs(e.M41));
             d = Math.Max(d, Math.Abs(e.M42));
@@ -55,17 +55,17 @@ namespace Intar.Tests {
 #if UNITY_5_3_OR_NEWER
         public static double Delta(UnityEngine.Matrix4x4 e, Matrix3x3I2F30 a) {
             var d = 0.0;
-            d = Math.Max(d, Math.Abs(e.m00 - a.C0.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m01 - a.C1.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m02 - a.C2.X.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.m00 - (float)a.C0.X));
+            d = Math.Max(d, Math.Abs(e.m01 - (float)a.C1.X));
+            d = Math.Max(d, Math.Abs(e.m02 - (float)a.C2.X));
             d = Math.Max(d, Math.Abs(e.m03));
-            d = Math.Max(d, Math.Abs(e.m10 - a.C0.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m11 - a.C1.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m12 - a.C2.Y.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.m10 - (float)a.C0.Y));
+            d = Math.Max(d, Math.Abs(e.m11 - (float)a.C1.Y));
+            d = Math.Max(d, Math.Abs(e.m12 - (float)a.C2.Y));
             d = Math.Max(d, Math.Abs(e.m13));
-            d = Math.Max(d, Math.Abs(e.m20 - a.C0.Z.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m21 - a.C1.Z.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.m22 - a.C2.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.m20 - (float)a.C0.Z));
+            d = Math.Max(d, Math.Abs(e.m21 - (float)a.C1.Z));
+            d = Math.Max(d, Math.Abs(e.m22 - (float)a.C2.Z));
             d = Math.Max(d, Math.Abs(e.m23));
             d = Math.Max(d, Math.Abs(e.m30));
             d = Math.Max(d, Math.Abs(e.m31));
@@ -78,15 +78,15 @@ namespace Intar.Tests {
 #if UNITY_2018_1_OR_NEWER
         public static double Delta(Unity.Mathematics.float3x3 e, Matrix3x3I2F30 a) {
             var d = 0.0;
-            d = Math.Max(d, Math.Abs(e.c0.x - a.C0.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c1.x - a.C1.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c2.x - a.C2.X.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c0.y - a.C0.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c1.y - a.C1.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c2.y - a.C2.Y.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c0.z - a.C0.Z.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c1.z - a.C1.Z.LossyToSingle()));
-            d = Math.Max(d, Math.Abs(e.c2.z - a.C2.Z.LossyToSingle()));
+            d = Math.Max(d, Math.Abs(e.c0.x - (float)a.C0.X));
+            d = Math.Max(d, Math.Abs(e.c1.x - (float)a.C1.X));
+            d = Math.Max(d, Math.Abs(e.c2.x - (float)a.C2.X));
+            d = Math.Max(d, Math.Abs(e.c0.y - (float)a.C0.Y));
+            d = Math.Max(d, Math.Abs(e.c1.y - (float)a.C1.Y));
+            d = Math.Max(d, Math.Abs(e.c2.y - (float)a.C2.Y));
+            d = Math.Max(d, Math.Abs(e.c0.z - (float)a.C0.Z));
+            d = Math.Max(d, Math.Abs(e.c1.z - (float)a.C1.Z));
+            d = Math.Max(d, Math.Abs(e.c2.z - (float)a.C2.Z));
             return d;
         }
 #endif // UNITY_2018_1_OR_NEWER
@@ -156,15 +156,15 @@ namespace Intar.Tests {
 
                 {
                     var mf1 = new System.Numerics.Matrix4x4(
-                        m1.C0.X.LossyToSingle(), m1.C1.X.LossyToSingle(), m1.C2.X.LossyToSingle(), 0,
-                        m1.C0.Y.LossyToSingle(), m1.C1.Y.LossyToSingle(), m1.C2.Y.LossyToSingle(), 0,
-                        m1.C0.Z.LossyToSingle(), m1.C1.Z.LossyToSingle(), m1.C2.Z.LossyToSingle(), 0,
+                        (float)m1.C0.X, (float)m1.C1.X, (float)m1.C2.X, 0,
+                        (float)m1.C0.Y, (float)m1.C1.Y, (float)m1.C2.Y, 0,
+                        (float)m1.C0.Z, (float)m1.C1.Z, (float)m1.C2.Z, 0,
                         0, 0, 0, 1
                     );
                     var mf2 = new System.Numerics.Matrix4x4(
-                        m2.C0.X.LossyToSingle(), m2.C1.X.LossyToSingle(), m2.C2.X.LossyToSingle(), 0,
-                        m2.C0.Y.LossyToSingle(), m2.C1.Y.LossyToSingle(), m2.C2.Y.LossyToSingle(), 0,
-                        m2.C0.Z.LossyToSingle(), m2.C1.Z.LossyToSingle(), m2.C2.Z.LossyToSingle(), 0,
+                        (float)m2.C0.X, (float)m2.C1.X, (float)m2.C2.X, 0,
+                        (float)m2.C0.Y, (float)m2.C1.Y, (float)m2.C2.Y, 0,
+                        (float)m2.C0.Z, (float)m2.C1.Z, (float)m2.C2.Z, 0,
                         0, 0, 0, 1
                     );
                     var e = mf1 * mf2;
@@ -230,7 +230,7 @@ namespace Intar.Tests {
             var dm3 = 0.0;
             for (var i = 0; i < 32768; i++) {
                 var angle = Utility.RandomI17F15(ref rng);
-                var rad = (float)(angle.LossyToSingle() * Math.PI / 2);
+                var rad = (float)angle * (float)(Math.PI / 2);
                 var a = Matrix3x3I2F30.RotateXP5(angle);
 
                 {
@@ -242,7 +242,7 @@ namespace Intar.Tests {
 
 #if UNITY_5_3_OR_NEWER
                 {
-                    var deg = (float)(angle.LossyToSingle() * 90);
+                    var deg = (float)angle * 90;
                     var e = UnityEngine.Matrix4x4.Rotate(UnityEngine.Quaternion.Euler(deg, 0, 0));
                     var d = Delta(e, a);
                     if (d > 0.1) { Assert.Fail(); };
@@ -276,7 +276,7 @@ namespace Intar.Tests {
             var dm3 = 0.0;
             for (var i = 0; i < 32768; i++) {
                 var angle = Utility.RandomI17F15(ref rng);
-                var rad = (float)(angle.LossyToSingle() * Math.PI / 2);
+                var rad = (float)angle * (float)(Math.PI / 2);
                 var a = Matrix3x3I2F30.RotateYP5(angle);
 
                 {
@@ -288,7 +288,7 @@ namespace Intar.Tests {
 
 #if UNITY_5_3_OR_NEWER
                 {
-                    var deg = (float)(angle.LossyToSingle() * 90);
+                    var deg = (float)angle * 90;
                     var e = UnityEngine.Matrix4x4.Rotate(UnityEngine.Quaternion.Euler(0, deg, 0));
                     var d = Delta(e, a);
                     if (d > 0.1) { Assert.Fail(); };
@@ -322,7 +322,7 @@ namespace Intar.Tests {
             var dm3 = 0.0;
             for (var i = 0; i < 32768; i++) {
                 var angle = Utility.RandomI17F15(ref rng);
-                var rad = (float)(angle.LossyToSingle() * Math.PI / 2);
+                var rad = (float)angle * (float)(Math.PI / 2);
                 var a = Matrix3x3I2F30.RotateZP5(angle);
 
                 {
@@ -334,7 +334,7 @@ namespace Intar.Tests {
 
 #if UNITY_5_3_OR_NEWER
                 {
-                    var deg = (float)(angle.LossyToSingle() * 90);
+                    var deg = (float)angle * 90;
                     var e = UnityEngine.Matrix4x4.Rotate(UnityEngine.Quaternion.Euler(0, 0, deg));
                     var d = Delta(e, a);
                     if (d > 0.1) { Assert.Fail(); };
@@ -371,9 +371,9 @@ namespace Intar.Tests {
 
                 {
                     var e
-                        = System.Numerics.Matrix4x4.CreateRotationX(angles.X.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationY(angles.Y.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationZ(angles.Z.LossyToSingle() * (float)Math.PI / 2);
+                        = System.Numerics.Matrix4x4.CreateRotationX((float)angles.X * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationY((float)angles.Y * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationZ((float)angles.Z * (float)(Math.PI / 2));
                     var d = Delta(System.Numerics.Matrix4x4.Transpose(e), a);
                     if (d > 0.1) { Assert.Fail(); };
                     dm1 = Math.Max(dm1, d);
@@ -408,9 +408,9 @@ namespace Intar.Tests {
 
                 {
                     var e
-                        = System.Numerics.Matrix4x4.CreateRotationX(angles.X.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationZ(angles.Z.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationY(angles.Y.LossyToSingle() * (float)Math.PI / 2);
+                        = System.Numerics.Matrix4x4.CreateRotationX((float)angles.X * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationZ((float)angles.Z * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationY((float)angles.Y * (float)(Math.PI / 2));
                     var d = Delta(System.Numerics.Matrix4x4.Transpose(e), a);
                     if (d > 0.1) { Assert.Fail(); };
                     dm1 = Math.Max(dm1, d);
@@ -445,9 +445,9 @@ namespace Intar.Tests {
 
                 {
                     var e
-                        = System.Numerics.Matrix4x4.CreateRotationY(angles.Y.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationX(angles.X.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationZ(angles.Z.LossyToSingle() * (float)Math.PI / 2);
+                        = System.Numerics.Matrix4x4.CreateRotationY((float)angles.Y * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationX((float)angles.X * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationZ((float)angles.Z * (float)(Math.PI / 2));
                     var d = Delta(System.Numerics.Matrix4x4.Transpose(e), a);
                     if (d > 0.1) { Assert.Fail(); };
                     dm1 = Math.Max(dm1, d);
@@ -482,9 +482,9 @@ namespace Intar.Tests {
 
                 {
                     var e
-                        = System.Numerics.Matrix4x4.CreateRotationY(angles.Y.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationZ(angles.Z.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationX(angles.X.LossyToSingle() * (float)Math.PI / 2);
+                        = System.Numerics.Matrix4x4.CreateRotationY((float)angles.Y * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationZ((float)angles.Z * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationX((float)angles.X * (float)(Math.PI / 2));
                     var d = Delta(System.Numerics.Matrix4x4.Transpose(e), a);
                     if (d > 0.1) { Assert.Fail(); };
                     dm1 = Math.Max(dm1, d);
@@ -520,9 +520,9 @@ namespace Intar.Tests {
 
                 {
                     var e
-                        = System.Numerics.Matrix4x4.CreateRotationZ(angles.Z.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationX(angles.X.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationY(angles.Y.LossyToSingle() * (float)Math.PI / 2);
+                        = System.Numerics.Matrix4x4.CreateRotationZ((float)angles.Z * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationX((float)angles.X * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationY((float)angles.Y * (float)(Math.PI / 2));
                     var d = Delta(System.Numerics.Matrix4x4.Transpose(e), a);
                     if (d > 0.1) { Assert.Fail(); };
                     dm1 = Math.Max(dm1, d);
@@ -571,9 +571,9 @@ namespace Intar.Tests {
 
                 {
                     var e
-                        = System.Numerics.Matrix4x4.CreateRotationZ(angles.Z.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationY(angles.Y.LossyToSingle() * (float)Math.PI / 2)
-                        * System.Numerics.Matrix4x4.CreateRotationX(angles.X.LossyToSingle() * (float)Math.PI / 2);
+                        = System.Numerics.Matrix4x4.CreateRotationZ((float)angles.Z * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationY((float)angles.Y * (float)(Math.PI / 2))
+                        * System.Numerics.Matrix4x4.CreateRotationX((float)angles.X * (float)(Math.PI / 2));
                     var d = Delta(System.Numerics.Matrix4x4.Transpose(e), a);
                     if (d > 0.1) { Assert.Fail(); };
                     dm1 = Math.Max(dm1, d);
@@ -619,7 +619,7 @@ namespace Intar.Tests {
                     var e = System.Numerics.Matrix4x4.Transpose(
                         System.Numerics.Matrix4x4.CreateFromAxisAngle(
                             (System.Numerics.Vector3)axis,
-                            (float)(angle.LossyToSingle() * Math.PI / 2)
+                            (float)angle * (float)(Math.PI / 2)
                         )
                     );
                     var d = Delta(e, a);
@@ -631,7 +631,7 @@ namespace Intar.Tests {
                 {
                     var e = UnityEngine.Matrix4x4.Rotate(
                         UnityEngine.Quaternion.AngleAxis(
-                            (float)(angle.LossyToSingle() * 90),
+                            (float)angle * 90,
                             (UnityEngine.Vector3)axis
                         )
                     );
@@ -645,7 +645,7 @@ namespace Intar.Tests {
                 {
                     var e = Unity.Mathematics.float3x3.AxisAngle(
                         (Unity.Mathematics.float3)axis,
-                        (float)(angle.LossyToSingle() * Math.PI / 2)
+                        (float)angle * (float)(Math.PI / 2)
                     );
                     var d = Delta(e, a);
                     if (d > 0.1) { Assert.Fail(); };

--- a/Intar.Tests/QuaternionTest.cs
+++ b/Intar.Tests/QuaternionTest.cs
@@ -16,29 +16,29 @@ namespace Intar.Tests {
         }
 
         public static double Delta(System.Numerics.Quaternion e, QuaternionI2F30 a) {
-            var x = Math.Abs(a.X.ToDouble() - e.X);
-            var y = Math.Abs(a.Y.ToDouble() - e.Y);
-            var z = Math.Abs(a.Z.ToDouble() - e.Z);
-            var w = Math.Abs(a.W.ToDouble() - e.W);
+            var x = Math.Abs((double)a.X - e.X);
+            var y = Math.Abs((double)a.Y - e.Y);
+            var z = Math.Abs((double)a.Z - e.Z);
+            var w = Math.Abs((double)a.W - e.W);
             return Math.Max(Math.Max(x, y), Math.Max(z, w));
         }
 
 #if UNITY_5_6_OR_NEWER
         public static double Delta(UnityEngine.Quaternion e, QuaternionI2F30 a) {
-            var x = Math.Abs(a.X.ToDouble() - e.x);
-            var y = Math.Abs(a.Y.ToDouble() - e.y);
-            var z = Math.Abs(a.Z.ToDouble() - e.z);
-            var w = Math.Abs(a.W.ToDouble() - e.w);
+            var x = Math.Abs((double)a.X - e.x);
+            var y = Math.Abs((double)a.Y - e.y);
+            var z = Math.Abs((double)a.Z - e.z);
+            var w = Math.Abs((double)a.W - e.w);
             return Math.Max(Math.Max(x, y), Math.Max(z, w));
         }
 #endif // UNITY_5_6_OR_NEWER
 
 #if UNITY_2018_1_OR_NEWER
         public static double Delta(Unity.Mathematics.quaternion e, QuaternionI2F30 a) {
-            var x = Math.Abs(a.X.ToDouble() - e.value.x);
-            var y = Math.Abs(a.Y.ToDouble() - e.value.y);
-            var z = Math.Abs(a.Z.ToDouble() - e.value.z);
-            var w = Math.Abs(a.W.ToDouble() - e.value.w);
+            var x = Math.Abs((double)a.X - e.value.x);
+            var y = Math.Abs((double)a.Y - e.value.y);
+            var z = Math.Abs((double)a.Z - e.value.z);
+            var w = Math.Abs((double)a.W - e.value.w);
             return Math.Max(Math.Max(x, y), Math.Max(z, w));
         }
 #endif // UNITY_2018_1_OR_NEWER
@@ -238,7 +238,7 @@ namespace Intar.Tests {
                     var e = System.Numerics.Quaternion.Lerp(
                         (System.Numerics.Quaternion)a,
                         (System.Numerics.Quaternion)b,
-                        t.LossyToSingle()
+                        (float)t
                     );
                     var d = Delta(e, actual);
                     if (d > delta) {
@@ -252,7 +252,7 @@ namespace Intar.Tests {
                     var e = UnityEngine.Quaternion.Lerp(
                         (UnityEngine.Quaternion)a,
                         (UnityEngine.Quaternion)b,
-                        t.LossyToSingle()
+                        (float)t
                     );
                     var d = Delta(e, actual);
                     if (d > delta) {
@@ -267,7 +267,7 @@ namespace Intar.Tests {
                     var e = Unity.Mathematics.math.nlerp(
                         (Unity.Mathematics.quaternion)a,
                         (Unity.Mathematics.quaternion)b,
-                        t.LossyToSingle()
+                        (float)t
                     );
                     var d = Delta(e, actual);
                     if (d > delta) {
@@ -435,7 +435,7 @@ namespace Intar.Tests {
                     var e = System.Numerics.Quaternion.Slerp(
                         (System.Numerics.Quaternion)a,
                         (System.Numerics.Quaternion)b,
-                        t.LossyToSingle()
+                        (float)t
                     );
                     var d = Delta(e, actual);
                     if (d > delta) {
@@ -449,7 +449,7 @@ namespace Intar.Tests {
                     var e = UnityEngine.Quaternion.Slerp(
                         (UnityEngine.Quaternion)a,
                         (UnityEngine.Quaternion)b,
-                        t.LossyToSingle()
+                        (float)t
                     );
                     var d = Delta(e, actual);
                     if (d > delta) {
@@ -464,7 +464,7 @@ namespace Intar.Tests {
                     var e = Unity.Mathematics.math.slerp(
                         (Unity.Mathematics.quaternion)a,
                         (Unity.Mathematics.quaternion)b,
-                        t.LossyToSingle()
+                        (float)t
                     );
                     var d = Delta(e, actual);
                     if (d > delta) {
@@ -491,8 +491,8 @@ namespace Intar.Tests {
                 var actualX = QuaternionI2F30.RotateXP5(angle);
                 var actualY = QuaternionI2F30.RotateYP5(angle);
                 var actualZ = QuaternionI2F30.RotateZP5(angle);
-                var rad = angle.LossyToSingle() * toRad;
-                var deg = angle.LossyToSingle() * 90;
+                var rad = (float)angle * toRad;
+                var deg = (float)angle * 90;
 
                 {
                     var eX = System.Numerics.Quaternion.CreateFromAxisAngle(System.Numerics.Vector3.UnitX, rad);
@@ -555,9 +555,9 @@ namespace Intar.Tests {
 
                 {
                     var e = System.Numerics.Quaternion.CreateFromYawPitchRoll(
-                        y.LossyToSingle() * toRad,
-                        x.LossyToSingle() * toRad,
-                        z.LossyToSingle() * toRad
+                        (float)y * toRad,
+                        (float)x * toRad,
+                        (float)z * toRad
                     );
                     var d = Delta(e, actual);
                     if (d > delta) {
@@ -569,9 +569,9 @@ namespace Intar.Tests {
 #if UNITY_5_3_OR_NEWER
                 {
                     var e = UnityEngine.Quaternion.Euler(
-                        x.LossyToSingle() * 90,
-                        y.LossyToSingle() * 90,
-                        z.LossyToSingle() * 90
+                        (float)x * 90,
+                        (float)y * 90,
+                        (float)z * 90
                     );
                     var d = Delta(e, actual);
                     if (d > delta) {
@@ -584,9 +584,9 @@ namespace Intar.Tests {
 #if UNITY_2018_1_OR_NEWER
                 {
                     var e = Unity.Mathematics.quaternion.EulerZXY(
-                        x.LossyToSingle() * toRad,
-                        y.LossyToSingle() * toRad,
-                        z.LossyToSingle() * toRad
+                        (float)x * toRad,
+                        (float)y * toRad,
+                        (float)z * toRad
                     );
 
                     var d = Delta(e, actual);
@@ -615,7 +615,7 @@ namespace Intar.Tests {
                 {
                     var e = System.Numerics.Quaternion.CreateFromAxisAngle(
                         (System.Numerics.Vector3)axis,
-                        angle.LossyToSingle() * toRad
+                        (float)angle * toRad
                     );
                     var d = Delta(e, actual);
                     if (d > delta) {
@@ -627,7 +627,7 @@ namespace Intar.Tests {
 #if UNITY_5_3_OR_NEWER
                 {
                     var e = UnityEngine.Quaternion.AngleAxis(
-                        angle.LossyToSingle() * 90,
+                        (float)angle * 90,
                         (UnityEngine.Vector3)axis
                     );
                     var d = Delta(e, actual);
@@ -642,7 +642,7 @@ namespace Intar.Tests {
                 {
                     var e = Unity.Mathematics.quaternion.AxisAngle(
                         (Unity.Mathematics.float3)axis,
-                        angle.LossyToSingle() * toRad
+                        (float)angle * toRad
                     );
                     var d = Delta(e, actual);
                     if (d > delta) {

--- a/Intar.Tests/Utility.cs
+++ b/Intar.Tests/Utility.cs
@@ -137,26 +137,26 @@ namespace Intar.Tests {
         #endregion
         #region Delta
         public static double Delta(System.Numerics.Vector3 v, Vector3I17F15 a) {
-            var x = Math.Abs(a.X.ToDouble() - v.X);
-            var y = Math.Abs(a.Y.ToDouble() - v.Y);
-            var z = Math.Abs(a.Z.ToDouble() - v.Z);
+            var x = Math.Abs((double)a.X - v.X);
+            var y = Math.Abs((double)a.Y - v.Y);
+            var z = Math.Abs((double)a.Z - v.Z);
             return Math.Max(Math.Max(x, y), z);
         }
 
 #if UNITY_5_3_OR_NEWER
         public static double Delta(UnityEngine.Vector3 v, Vector3I17F15 a) {
-            var x = Math.Abs(a.X.ToDouble() - v.x);
-            var y = Math.Abs(a.Y.ToDouble() - v.y);
-            var z = Math.Abs(a.Z.ToDouble() - v.z);
+            var x = Math.Abs((double)a.X - v.x);
+            var y = Math.Abs((double)a.Y - v.y);
+            var z = Math.Abs((double)a.Z - v.z);
             return Math.Max(Math.Max(x, y), z);
         }
 #endif // UNITY_5_3_OR_NEWER
 
 #if UNITY_2018_1_OR_NEWER
         public static double Delta(Unity.Mathematics.float3 v, Vector3I17F15 a) {
-            var x = Math.Abs(a.X.ToDouble() - v.x);
-            var y = Math.Abs(a.Y.ToDouble() - v.y);
-            var z = Math.Abs(a.Z.ToDouble() - v.z);
+            var x = Math.Abs((double)a.X - v.x);
+            var y = Math.Abs((double)a.Y - v.y);
+            var z = Math.Abs((double)a.Z - v.z);
             return Math.Max(Math.Max(x, y), z);
         }
 #endif // UNITY_2018_1_OR_NEWER

--- a/Intar.Tests/VectorTest.cs
+++ b/Intar.Tests/VectorTest.cs
@@ -5,10 +5,10 @@ namespace Intar.Tests {
     public class VectorTest {
         static void Test(I17F15 x, I17F15 y, I17F15 z, I17F15 w) {
             var p = new System.Numerics.Vector4(
-                x.LossyToSingle(),
-                y.LossyToSingle(),
-                z.LossyToSingle(),
-                w.LossyToSingle());
+                (float)x,
+                (float)y,
+                (float)z,
+                (float)w);
             var q = new Vector4I17F15(x, y, z, w);
             {
                 var e = System.Numerics.Vector4.Normalize(p);
@@ -21,17 +21,17 @@ namespace Intar.Tests {
                         float.IsNaN(e.W));
                 }
                 const double delta = 0.00004;
-                Utility.AssertAreEqual(e.X, (a?.X ?? I17F15.Zero).LossyToSingle(), delta);
-                Utility.AssertAreEqual(e.Y, (a?.Y ?? I17F15.Zero).LossyToSingle(), delta);
-                Utility.AssertAreEqual(e.Z, (a?.Z ?? I17F15.Zero).LossyToSingle(), delta);
-                Utility.AssertAreEqual(e.W, (a?.W ?? I17F15.Zero).LossyToSingle(), delta);
+                Utility.AssertAreEqual(e.X, (float)(a?.X ?? I17F15.Zero), delta);
+                Utility.AssertAreEqual(e.Y, (float)(a?.Y ?? I17F15.Zero), delta);
+                Utility.AssertAreEqual(e.Z, (float)(a?.Z ?? I17F15.Zero), delta);
+                Utility.AssertAreEqual(e.W, (float)(a?.W ?? I17F15.Zero), delta);
             }
         }
         static void Test(I17F15 x, I17F15 y, I17F15 z) {
             var p = new System.Numerics.Vector3(
-                x.LossyToSingle(),
-                y.LossyToSingle(),
-                z.LossyToSingle());
+                (float)x,
+                (float)y,
+                (float)z);
             var q = new Vector3I17F15(x, y, z);
             {
                 var e = System.Numerics.Vector3.Normalize(p);
@@ -43,25 +43,25 @@ namespace Intar.Tests {
                         float.IsNaN(e.Z));
                 }
                 const double delta = 0.00004;
-                Utility.AssertAreEqual(e.X, (a?.X ?? I17F15.Zero).LossyToSingle(), delta);
-                Utility.AssertAreEqual(e.Y, (a?.Y ?? I17F15.Zero).LossyToSingle(), delta);
-                Utility.AssertAreEqual(e.Z, (a?.Z ?? I17F15.Zero).LossyToSingle(), delta);
+                Utility.AssertAreEqual(e.X, (float)(a?.X ?? I17F15.Zero), delta);
+                Utility.AssertAreEqual(e.Y, (float)(a?.Y ?? I17F15.Zero), delta);
+                Utility.AssertAreEqual(e.Z, (float)(a?.Z ?? I17F15.Zero), delta);
             }
             {
                 var a = q.LengthSquared();
                 const double delta = 1024;
-                Utility.AssertAreEqual(p.LengthSquared(), a.LossyToSingle(), delta);
+                Utility.AssertAreEqual(p.LengthSquared(), (float)a, delta);
             }
             {
                 var a = q.Length();
                 const double delta = 0.008;
-                Utility.AssertAreEqual(p.Length(), a.LossyToSingle(), delta);
+                Utility.AssertAreEqual(p.Length(), (float)a, delta);
             }
         }
         static void Test(I17F15 x, I17F15 y) {
             var p = new System.Numerics.Vector2(
-                x.LossyToSingle(),
-                y.LossyToSingle());
+                (float)x,
+                (float)y);
             var q = new Vector2I17F15(x, y);
             {
                 var e = System.Numerics.Vector2.Normalize(p);
@@ -72,18 +72,18 @@ namespace Intar.Tests {
                         float.IsNaN(e.Y));
                 }
                 const double delta = 0.00004;
-                Utility.AssertAreEqual(e.X, (a?.X ?? I17F15.Zero).LossyToSingle(), delta);
-                Utility.AssertAreEqual(e.Y, (a?.Y ?? I17F15.Zero).LossyToSingle(), delta);
+                Utility.AssertAreEqual(e.X, (float)(a?.X ?? I17F15.Zero), delta);
+                Utility.AssertAreEqual(e.Y, (float)(a?.Y ?? I17F15.Zero), delta);
             }
             {
                 var a = q.LengthSquared();
                 const double delta = 1024;
-                Utility.AssertAreEqual(p.LengthSquared(), a.LossyToSingle(), delta);
+                Utility.AssertAreEqual(p.LengthSquared(), (float)a, delta);
             }
             {
                 var a = q.Length();
                 const double delta = 0.008;
-                Utility.AssertAreEqual(p.Length(), a.LossyToSingle(), delta);
+                Utility.AssertAreEqual(p.Length(), (float)a, delta);
             }
         }
 

--- a/Intar/AffineTransform3I17F15.gen.cs
+++ b/Intar/AffineTransform3I17F15.gen.cs
@@ -59,10 +59,10 @@ namespace Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator System.Numerics.Matrix4x4(AffineTransform3I17F15 a) {
             return new System.Numerics.Matrix4x4(
-                a.RotationScale.C0.X.LossyToSingle(), a.RotationScale.C0.Y.LossyToSingle(), a.RotationScale.C0.Z.LossyToSingle(), 0,
-                a.RotationScale.C1.X.LossyToSingle(), a.RotationScale.C1.Y.LossyToSingle(), a.RotationScale.C1.Z.LossyToSingle(), 0,
-                a.RotationScale.C2.X.LossyToSingle(), a.RotationScale.C2.Y.LossyToSingle(), a.RotationScale.C2.Z.LossyToSingle(), 0,
-                a.Translation.X.LossyToSingle(), a.Translation.Y.LossyToSingle(), a.Translation.Z.LossyToSingle(), 1
+                (float)a.RotationScale.C0.X, (float)a.RotationScale.C0.Y, (float)a.RotationScale.C0.Z, 0,
+                (float)a.RotationScale.C1.X, (float)a.RotationScale.C1.Y, (float)a.RotationScale.C1.Z, 0,
+                (float)a.RotationScale.C2.X, (float)a.RotationScale.C2.Y, (float)a.RotationScale.C2.Z, 0,
+                (float)a.Translation.X, (float)a.Translation.Y, (float)a.Translation.Z, 1
             );
         }
 
@@ -70,10 +70,10 @@ namespace Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator UnityEngine.Matrix4x4(AffineTransform3I17F15 a) {
             return new UnityEngine.Matrix4x4(
-                new UnityEngine.Vector4(a.RotationScale.C0.X.LossyToSingle(), a.RotationScale.C0.Y.LossyToSingle(), a.RotationScale.C0.Z.LossyToSingle(), 0),
-                new UnityEngine.Vector4(a.RotationScale.C1.X.LossyToSingle(), a.RotationScale.C1.Y.LossyToSingle(), a.RotationScale.C1.Z.LossyToSingle(), 0),
-                new UnityEngine.Vector4(a.RotationScale.C2.X.LossyToSingle(), a.RotationScale.C2.Y.LossyToSingle(), a.RotationScale.C2.Z.LossyToSingle(), 0),
-                new UnityEngine.Vector4(a.Translation.X.LossyToSingle(), a.Translation.Y.LossyToSingle(), a.Translation.Z.LossyToSingle(), 1)
+                new UnityEngine.Vector4((float)a.RotationScale.C0.X, (float)a.RotationScale.C0.Y, (float)a.RotationScale.C0.Z, 0),
+                new UnityEngine.Vector4((float)a.RotationScale.C1.X, (float)a.RotationScale.C1.Y, (float)a.RotationScale.C1.Z, 0),
+                new UnityEngine.Vector4((float)a.RotationScale.C2.X, (float)a.RotationScale.C2.Y, (float)a.RotationScale.C2.Z, 0),
+                new UnityEngine.Vector4((float)a.Translation.X, (float)a.Translation.Y, (float)a.Translation.Z, 1)
             );
         }
 #endif // UNITY_5_3_OR_NEWER
@@ -82,9 +82,9 @@ namespace Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator Unity.Mathematics.float4x4(AffineTransform3I17F15 a) {
             return new Unity.Mathematics.float4x4(
-                a.RotationScale.C0.X.LossyToSingle(), a.RotationScale.C1.X.LossyToSingle(), a.RotationScale.C2.X.LossyToSingle(), a.Translation.X.LossyToSingle(),
-                a.RotationScale.C0.Y.LossyToSingle(), a.RotationScale.C1.Y.LossyToSingle(), a.RotationScale.C2.Y.LossyToSingle(), a.Translation.Y.LossyToSingle(),
-                a.RotationScale.C0.Z.LossyToSingle(), a.RotationScale.C1.Z.LossyToSingle(), a.RotationScale.C2.Z.LossyToSingle(), a.Translation.Z.LossyToSingle(),
+                (float)a.RotationScale.C0.X, (float)a.RotationScale.C1.X, (float)a.RotationScale.C2.X, (float)a.Translation.X,
+                (float)a.RotationScale.C0.Y, (float)a.RotationScale.C1.Y, (float)a.RotationScale.C2.Y, (float)a.Translation.Y,
+                (float)a.RotationScale.C0.Z, (float)a.RotationScale.C1.Z, (float)a.RotationScale.C2.Z, (float)a.Translation.Z,
                 0, 0, 0, 1
             );
         }

--- a/Intar/I17F15.gen.cs
+++ b/Intar/I17F15.gen.cs
@@ -128,7 +128,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -143,7 +143,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -457,7 +457,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -485,7 +484,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -610,7 +608,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -664,14 +662,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double ToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(I17F15 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(I17F15 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/I2F30.gen.cs
+++ b/Intar/I2F30.gen.cs
@@ -128,7 +128,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -143,7 +143,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -307,7 +307,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -335,7 +334,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -460,7 +458,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -514,14 +512,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double ToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(I2F30 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(I2F30 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/I2F62.gen.cs
+++ b/Intar/I2F62.gen.cs
@@ -139,7 +139,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -154,7 +154,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -322,7 +322,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -350,7 +349,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -475,7 +473,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -529,14 +527,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(I2F62 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(I2F62 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/I33F31.gen.cs
+++ b/Intar/I33F31.gen.cs
@@ -139,7 +139,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -154,7 +154,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -549,7 +549,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -577,7 +576,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -702,7 +700,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -756,14 +754,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(I33F31 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(I33F31 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/I34F30.gen.cs
+++ b/Intar/I34F30.gen.cs
@@ -139,7 +139,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -154,7 +154,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -321,7 +321,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -349,7 +348,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -474,7 +472,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -528,14 +526,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(I34F30 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(I34F30 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/I4F60.gen.cs
+++ b/Intar/I4F60.gen.cs
@@ -139,7 +139,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -154,7 +154,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -321,7 +321,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -349,7 +348,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -474,7 +472,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -528,14 +526,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(I4F60 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(I4F60 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/I68F60.gen.cs
+++ b/Intar/I68F60.gen.cs
@@ -107,7 +107,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -122,7 +122,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -242,7 +242,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -270,7 +269,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -391,7 +389,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -445,14 +443,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(I68F60 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(I68F60 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/I8F120.gen.cs
+++ b/Intar/I8F120.gen.cs
@@ -107,7 +107,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -122,7 +122,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -242,7 +242,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -270,7 +269,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -391,7 +389,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -445,14 +443,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(I8F120 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(I8F120 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/Matrix3x3I17F15.gen.cs
+++ b/Intar/Matrix3x3I17F15.gen.cs
@@ -112,9 +112,9 @@ namespace Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator Unity.Mathematics.float3x3(Matrix3x3I17F15 a) {
             return new Unity.Mathematics.float3x3(
-                a.C0.X.LossyToSingle(), a.C1.X.LossyToSingle(), a.C2.X.LossyToSingle(),
-                a.C0.Y.LossyToSingle(), a.C1.Y.LossyToSingle(), a.C2.Y.LossyToSingle(),
-                a.C0.Z.LossyToSingle(), a.C1.Z.LossyToSingle(), a.C2.Z.LossyToSingle()
+                (float)a.C0.X, (float)a.C1.X, (float)a.C2.X,
+                (float)a.C0.Y, (float)a.C1.Y, (float)a.C2.Y,
+                (float)a.C0.Z, (float)a.C1.Z, (float)a.C2.Z
             );
         }
 #endif // UNITY_2018_1_OR_NEWER

--- a/Intar/Matrix3x3I2F30.gen.cs
+++ b/Intar/Matrix3x3I2F30.gen.cs
@@ -112,9 +112,9 @@ namespace Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator Unity.Mathematics.float3x3(Matrix3x3I2F30 a) {
             return new Unity.Mathematics.float3x3(
-                a.C0.X.LossyToSingle(), a.C1.X.LossyToSingle(), a.C2.X.LossyToSingle(),
-                a.C0.Y.LossyToSingle(), a.C1.Y.LossyToSingle(), a.C2.Y.LossyToSingle(),
-                a.C0.Z.LossyToSingle(), a.C1.Z.LossyToSingle(), a.C2.Z.LossyToSingle()
+                (float)a.C0.X, (float)a.C1.X, (float)a.C2.X,
+                (float)a.C0.Y, (float)a.C1.Y, (float)a.C2.Y,
+                (float)a.C0.Z, (float)a.C1.Z, (float)a.C2.Z
             );
         }
 #endif // UNITY_2018_1_OR_NEWER

--- a/Intar/QuaternionI2F30.gen.cs
+++ b/Intar/QuaternionI2F30.gen.cs
@@ -74,20 +74,20 @@ namespace Intar {
 
         public static explicit operator System.Numerics.Quaternion(QuaternionI2F30 q) {
             return new System.Numerics.Quaternion(
-                q.X.LossyToSingle(),
-                q.Y.LossyToSingle(),
-                q.Z.LossyToSingle(),
-                q.W.LossyToSingle()
+                (float)q.X,
+                (float)q.Y,
+                (float)q.Z,
+                (float)q.W
             );
         }
 
 #if UNITY_5_6_OR_NEWER
         public static explicit operator UnityEngine.Quaternion(QuaternionI2F30 q) {
             return new UnityEngine.Quaternion(
-                q.X.LossyToSingle(),
-                q.Y.LossyToSingle(),
-                q.Z.LossyToSingle(),
-                q.W.LossyToSingle()
+                (float)q.X,
+                (float)q.Y,
+                (float)q.Z,
+                (float)q.W
             );
         }
 #endif // UNITY_5_6_OR_NEWER
@@ -95,10 +95,10 @@ namespace Intar {
 #if UNITY_2018_1_OR_NEWER
         public static explicit operator Unity.Mathematics.quaternion(QuaternionI2F30 q) {
             return new Unity.Mathematics.quaternion(
-                q.X.LossyToSingle(),
-                q.Y.LossyToSingle(),
-                q.Z.LossyToSingle(),
-                q.W.LossyToSingle()
+                (float)q.X,
+                (float)q.Y,
+                (float)q.Z,
+                (float)q.W
             );
         }
 #endif // UNITY_2018_1_OR_NEWER

--- a/Intar/U17F15.gen.cs
+++ b/Intar/U17F15.gen.cs
@@ -126,7 +126,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -141,7 +141,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -261,7 +261,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -289,7 +288,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -414,7 +412,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -468,14 +466,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double ToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(U17F15 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(U17F15 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/U2F30.gen.cs
+++ b/Intar/U2F30.gen.cs
@@ -126,7 +126,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => ToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -141,7 +141,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return ToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -261,7 +261,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -289,7 +288,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -414,7 +412,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -468,14 +466,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double ToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(U2F30 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(U2F30 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/U2F62.gen.cs
+++ b/Intar/U2F62.gen.cs
@@ -137,7 +137,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -152,7 +152,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -262,7 +262,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -290,7 +289,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -415,7 +413,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -469,14 +467,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(U2F62 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(U2F62 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/U33F31.gen.cs
+++ b/Intar/U33F31.gen.cs
@@ -137,7 +137,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -152,7 +152,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -262,7 +262,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -290,7 +289,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -415,7 +413,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -469,14 +467,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(U33F31 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(U33F31 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/U34F30.gen.cs
+++ b/Intar/U34F30.gen.cs
@@ -137,7 +137,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -152,7 +152,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -276,7 +276,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -304,7 +303,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -429,7 +427,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -483,14 +481,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(U34F30 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(U34F30 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/U4F60.gen.cs
+++ b/Intar/U4F60.gen.cs
@@ -137,7 +137,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -152,7 +152,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -276,7 +276,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -304,7 +303,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -429,7 +427,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -483,14 +481,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(U4F60 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(U4F60 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/U68F60.gen.cs
+++ b/Intar/U68F60.gen.cs
@@ -105,7 +105,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -120,7 +120,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -226,7 +226,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -254,7 +253,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -375,7 +373,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -429,14 +427,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(U68F60 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(U68F60 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 

--- a/Intar/U8F120.gen.cs
+++ b/Intar/U8F120.gen.cs
@@ -105,7 +105,7 @@ namespace Intar {
         public override int GetHashCode() => Bits.GetHashCode();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => LossyToDouble().ToString((IFormatProvider)null);
+        public override string ToString() => ((double)this).ToString((IFormatProvider)null);
 
         #endregion
 
@@ -120,7 +120,7 @@ namespace Intar {
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ToString(string format, IFormatProvider formatProvider) {
-            return LossyToDouble().ToString(format, formatProvider);
+            return ((double)this).ToString(format, formatProvider);
         }
 
         #endregion
@@ -226,7 +226,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-
         #region Conversion from floating-point number
 
         // decimal からの型変換は基数 (Radix) が 2 のべき乗でないため実装しない。
@@ -254,7 +253,6 @@ namespace Intar {
         }
 
         #endregion
-
         #region Conversion from fixed-point number
 
         /// <summary>
@@ -375,7 +373,7 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Convert to integer
+        #region Conversion to integer
 
         /// <summary>
         /// <para><see cref="int" /> への変換を行います。</para>
@@ -429,14 +427,16 @@ namespace Intar {
 
 #endif // NET7_0_OR_GREATER
         #endregion
-
-        #region Convert to floating-point number
+        #region Conversion to floating-point number
 
         // 浮動小数点数への変換は必ず成功する。
         // 除算は最適化によって乗算に置き換えられることを期待する。
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public float LossyToSingle() => (float)Bits / (float)OneRepr;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public double LossyToDouble() => (double)Bits / (double)OneRepr;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(U8F120 v) => (float)v.Bits / (float)OneRepr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator double(U8F120 v) => (double)v.Bits / (double)OneRepr;
 
         #endregion
 


### PR DESCRIPTION
ToSingle, ToDouble を廃止し,
一般的な C# の変換演算子のインタフェースに変更した.