### PR TITLE
Segment2I17F15.Intersects 精度を改善 他

### DIFF
--- a/Intar.Tests/Geometry/SegmentTest.cs
+++ b/Intar.Tests/Geometry/SegmentTest.cs
@@ -3,411 +3,224 @@ using NUnit.Framework;
 
 namespace Intar.Tests.Geometry {
     public class SegmentTest {
+        static void AssertIntersects(Segment2I17F15 a, Segment2I17F15 b, bool cond) {
+            var c = new Segment2I17F15(a.P2, a.P1);
+            var d = new Segment2I17F15(b.P2, b.P1);
+            var e = new Segment2I17F15(a.P1, a.P1);
+            var f = new Segment2I17F15(a.P2, a.P2);
+            var g = new Segment2I17F15(b.P1, b.P1);
+            var h = new Segment2I17F15(b.P2, b.P2);
+            if (!a.Intersects(a) ||
+                !a.Intersects(c) ||
+                !b.Intersects(b) ||
+                !b.Intersects(d) ||
+                !c.Intersects(a) ||
+                !c.Intersects(c) ||
+                !d.Intersects(b) ||
+                !d.Intersects(d)) {
+                Assert.Fail();
+            }
+            if (!e.Intersects(e) ||
+                !f.Intersects(f) ||
+                !g.Intersects(g) ||
+                !h.Intersects(h)) {
+                Assert.Fail();
+            }
+            if (!a.Intersects(e) ||
+                !a.Intersects(f) ||
+                !b.Intersects(g) ||
+                !b.Intersects(h) ||
+                !c.Intersects(e) ||
+                !c.Intersects(f) ||
+                !d.Intersects(g) ||
+                !d.Intersects(h)) {
+                Assert.Fail();
+            }
+            if (a.Intersects(b) != cond ||
+                a.Intersects(d) != cond ||
+                b.Intersects(a) != cond ||
+                b.Intersects(c) != cond ||
+                c.Intersects(b) != cond ||
+                c.Intersects(d) != cond ||
+                d.Intersects(a) != cond ||
+                d.Intersects(c) != cond) {
+                Assert.Fail();
+            }
+            if (!cond) {
+                if (a.Intersects(g) ||
+                    a.Intersects(h) ||
+                    b.Intersects(e) ||
+                    b.Intersects(f) ||
+                    c.Intersects(g) ||
+                    c.Intersects(h) ||
+                    d.Intersects(e) ||
+                    d.Intersects(f)) {
+                    Assert.Fail();
+                }
+            }
+        }
+        static void AssertOverlaps(Segment2I17F15 a, Segment2I17F15 b, bool cond) {
+            var c = new Segment2I17F15(a.P2, a.P1);
+            var d = new Segment2I17F15(b.P2, b.P1);
+            var e = new Segment2I17F15(a.P1, a.P1);
+            var f = new Segment2I17F15(a.P2, a.P2);
+            var g = new Segment2I17F15(b.P1, b.P1);
+            var h = new Segment2I17F15(b.P2, b.P2);
+            if (a.Overlaps(a) ||
+                a.Overlaps(c) ||
+                b.Overlaps(b) ||
+                b.Overlaps(d) ||
+                c.Overlaps(a) ||
+                c.Overlaps(c) ||
+                d.Overlaps(b) ||
+                d.Overlaps(d)) {
+                Assert.Fail();
+            }
+            if (a.Overlaps(b) != cond ||
+                a.Overlaps(d) != cond ||
+                b.Overlaps(a) != cond ||
+                b.Overlaps(c) != cond ||
+                c.Overlaps(b) != cond ||
+                c.Overlaps(d) != cond ||
+                d.Overlaps(a) != cond ||
+                d.Overlaps(c) != cond) {
+                Assert.Fail();
+            }
+            if (a.Overlaps(e) ||
+                a.Overlaps(f) ||
+                b.Overlaps(g) ||
+                b.Overlaps(h) ||
+                c.Overlaps(e) ||
+                c.Overlaps(f) ||
+                d.Overlaps(g) ||
+                d.Overlaps(h) ||
+                e.Overlaps(a) ||
+                e.Overlaps(c) ||
+                f.Overlaps(a) ||
+                f.Overlaps(c) ||
+                g.Overlaps(b) ||
+                g.Overlaps(d) ||
+                h.Overlaps(b) ||
+                h.Overlaps(d)) {
+                Assert.Fail();
+            }
+        }
         [Test]
         public static void TestSegment() {
             var p1 = Vector2I17F15.Zero;
             var p2 = Vector2I17F15.UnitX;
             var p3 = Vector2I17F15.UnitY;
             var p4 = Vector2I17F15.One;
+
+            // 点と点
             {
-                var l = new Segment2I17F15[][] {
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p1, p1),
-                        new Segment2I17F15(p1, p2),
-                        new Segment2I17F15(p2, p2),
-                        new Segment2I17F15(p3, p3),
-                        new Segment2I17F15(p3, p4),
-                        new Segment2I17F15(p4, p4),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p1, p1),
-                        new Segment2I17F15(p1, p3),
-                        new Segment2I17F15(p2, p2),
-                        new Segment2I17F15(p2, p4),
-                        new Segment2I17F15(p3, p3),
-                        new Segment2I17F15(p4, p4),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p1, p1),
-                        new Segment2I17F15(p1, p4),
-                        new Segment2I17F15(p2, p2),
-                        new Segment2I17F15(p3, p3),
-                        new Segment2I17F15(p4, p4),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p1, p1),
-                        new Segment2I17F15(p2, p2),
-                        new Segment2I17F15(p2, p3),
-                        new Segment2I17F15(p3, p3),
-                        new Segment2I17F15(p4, p4),
-                    },
+                var segs = new Segment2I17F15[] {
+                    new Segment2I17F15(p1, p1),
+                    new Segment2I17F15(p2, p2),
+                    new Segment2I17F15(p3, p3),
+                    new Segment2I17F15(p4, p4),
                 };
-                foreach (var segments in l) {
-                    foreach (var a in segments) {
-                        foreach (var b in segments) {
-                            if (!a.P1.Equals(a.P2)) {
-                                var c = new Segment2I17F15(a.P2, a.P1);
-                                if (!b.P1.Equals(b.P2)) {
-                                    var d = new Segment2I17F15(b.P2, b.P1);
-                                    if (c.Intersects(d)) {
-                                        Assert.Fail();
-                                    }
-                                    if (d.Intersects(c)) {
-                                        Assert.Fail();
-                                    }
-                                    if (c.Overlaps(d)) {
-                                        Assert.Fail();
-                                    }
-                                    if (d.Overlaps(c)) {
-                                        Assert.Fail();
-                                    }
-                                }
-                                if (a.Intersects(c)) {
-                                    Assert.Fail();
-                                }
-                                if (b.Intersects(c)) {
-                                    Assert.Fail();
-                                }
-                                if (c.Intersects(a)) {
-                                    Assert.Fail();
-                                }
-                                if (c.Intersects(b)) {
-                                    Assert.Fail();
-                                }
-                                if (c.Intersects(c)) {
-                                    Assert.Fail();
-                                }
-                                if (a.Overlaps(c)) {
-                                    Assert.Fail();
-                                }
-                                if (b.Overlaps(c)) {
-                                    Assert.Fail();
-                                }
-                                if (c.Overlaps(a)) {
-                                    Assert.Fail();
-                                }
-                                if (c.Overlaps(b)) {
-                                    Assert.Fail();
-                                }
-                                if (c.Overlaps(c)) {
-                                    Assert.Fail();
-                                }
-                            } else if (!b.P1.Equals(b.P2)) {
-                                var d = new Segment2I17F15(b.P2, b.P1);
-                                if (a.Intersects(d)) {
-                                    Assert.Fail();
-                                }
-                                if (b.Intersects(d)) {
-                                    Assert.Fail();
-                                }
-                                if (d.Intersects(a)) {
-                                    Assert.Fail();
-                                }
-                                if (d.Intersects(b)) {
-                                    Assert.Fail();
-                                }
-                                if (d.Intersects(d)) {
-                                    Assert.Fail();
-                                }
-                                if (a.Overlaps(d)) {
-                                    Assert.Fail();
-                                }
-                                if (b.Overlaps(d)) {
-                                    Assert.Fail();
-                                }
-                                if (d.Overlaps(a)) {
-                                    Assert.Fail();
-                                }
-                                if (d.Overlaps(b)) {
-                                    Assert.Fail();
-                                }
-                                if (d.Overlaps(d)) {
-                                    Assert.Fail();
-                                }
-                            }
-                            if (a.Intersects(a)) {
-                                Assert.Fail();
-                            }
-                            if (a.Intersects(b)) {
-                                Assert.Fail();
-                            }
-                            if (b.Intersects(a)) {
-                                Assert.Fail();
-                            }
-                            if (b.Intersects(b)) {
-                                Assert.Fail();
-                            }
-                            if (a.Overlaps(a)) {
-                                Assert.Fail();
-                            }
-                            if (a.Overlaps(b)) {
-                                Assert.Fail();
-                            }
-                            if (b.Overlaps(a)) {
-                                Assert.Fail();
-                            }
-                            if (b.Overlaps(b)) {
-                                Assert.Fail();
-                            }
+                foreach (var a in segs) {
+                    foreach (var b in segs) {
+                        if (a.Equals(b)) {
+                            continue;
                         }
+                        AssertIntersects(a, b, false);
+                        AssertOverlaps(a, b, false);
                     }
                 }
             }
+
+            // !Intersects, !Overlaps
+            {
+                var l = new Segment2I17F15[][] {
+                    new Segment2I17F15[] {
+                        new Segment2I17F15(p1, p2),
+                        new Segment2I17F15(p3, p4),
+                    },
+                    new Segment2I17F15[] {
+                        new Segment2I17F15(p1, p3),
+                        new Segment2I17F15(p2, p4),
+                    },
+                    new Segment2I17F15[] {
+                        new Segment2I17F15(p2, p4),
+                        new Segment2I17F15(p1, p3),
+                    },
+                    new Segment2I17F15[] {
+                        new Segment2I17F15(p3, p4),
+                        new Segment2I17F15(p1, p2),
+                    },
+                    new Segment2I17F15[] {
+                        new Segment2I17F15(p1, p4),
+                        new Segment2I17F15(p2, p2),
+                        new Segment2I17F15(p3, p3),
+                    },
+                    new Segment2I17F15[] {
+                        new Segment2I17F15(p2, p3),
+                        new Segment2I17F15(p1, p1),
+                        new Segment2I17F15(p4, p4),
+                    },
+                };
+                foreach (var segs in l) {
+                    for (var i = 1; i < segs.Length; i++) {
+                        AssertIntersects(segs[0], segs[i], false);
+                        AssertOverlaps(segs[0], segs[i], false);
+                    }
+                }
+            }
+
+            // Intersects, !Overlaps
             {
                 var l = new Segment2I17F15[][] {
                     new Segment2I17F15[] {
                         new Segment2I17F15(p1, p2),
                         new Segment2I17F15(p1, p3),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p1, p2),
-                        new Segment2I17F15(p1, p4),
+                        new Segment2I17F15(p2, p4),
                     },
                     new Segment2I17F15[] {
                         new Segment2I17F15(p1, p3),
+                        new Segment2I17F15(p1, p2),
+                        new Segment2I17F15(p3, p4),
+                    },
+                    new Segment2I17F15[] {
+                        new Segment2I17F15(p2, p4),
+                        new Segment2I17F15(p2, p1),
+                        new Segment2I17F15(p4, p3),
+                    },
+                    new Segment2I17F15[] {
+                        new Segment2I17F15(p3, p4),
+                        new Segment2I17F15(p3, p1),
+                        new Segment2I17F15(p4, p2),
+                    },
+                    new Segment2I17F15[] {
                         new Segment2I17F15(p1, p4),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p2, p1),
-                        new Segment2I17F15(p2, p3),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p2, p1),
-                        new Segment2I17F15(p2, p4),
+                        new Segment2I17F15(p1, p2),
+                        new Segment2I17F15(p1, p3),
+                        new Segment2I17F15(p4, p2),
+                        new Segment2I17F15(p4, p3),
                     },
                     new Segment2I17F15[] {
                         new Segment2I17F15(p2, p3),
+                        new Segment2I17F15(p2, p1),
                         new Segment2I17F15(p2, p4),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p3, p1),
-                        new Segment2I17F15(p3, p2),
-                    },
-                    new Segment2I17F15[] {
                         new Segment2I17F15(p3, p1),
                         new Segment2I17F15(p3, p4),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p3, p2),
-                        new Segment2I17F15(p3, p4),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p4, p1),
-                        new Segment2I17F15(p4, p2),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p4, p1),
-                        new Segment2I17F15(p4, p3),
-                    },
-                    new Segment2I17F15[] {
-                        new Segment2I17F15(p4, p2),
-                        new Segment2I17F15(p4, p3),
                     },
                 };
-                foreach (var segments in l) {
-                    var a = segments[0];
-                    var b = segments[1];
-                    var c = new Segment2I17F15(a.P2, a.P1);
-                    var d = new Segment2I17F15(b.P2, b.P1);
-                    if (a.Intersects(a)) {
-                        Assert.Fail();
-                    }
-                    if (a.Intersects(c)) {
-                        Assert.Fail();
-                    }
-                    if (b.Intersects(b)) {
-                        Assert.Fail();
-                    }
-                    if (b.Intersects(d)) {
-                        Assert.Fail();
-                    }
-                    if (c.Intersects(a)) {
-                        Assert.Fail();
-                    }
-                    if (c.Intersects(c)) {
-                        Assert.Fail();
-                    }
-                    if (d.Intersects(b)) {
-                        Assert.Fail();
-                    }
-                    if (d.Intersects(d)) {
-                        Assert.Fail();
-                    }
-                    if (a.Overlaps(a)) {
-                        Assert.Fail();
-                    }
-                    if (a.Overlaps(b)) {
-                        Assert.Fail();
-                    }
-                    if (a.Overlaps(c)) {
-                        Assert.Fail();
-                    }
-                    if (a.Overlaps(d)) {
-                        Assert.Fail();
-                    }
-                    if (b.Overlaps(a)) {
-                        Assert.Fail();
-                    }
-                    if (b.Overlaps(b)) {
-                        Assert.Fail();
-                    }
-                    if (b.Overlaps(c)) {
-                        Assert.Fail();
-                    }
-                    if (b.Overlaps(d)) {
-                        Assert.Fail();
-                    }
-                    if (c.Overlaps(a)) {
-                        Assert.Fail();
-                    }
-                    if (c.Overlaps(b)) {
-                        Assert.Fail();
-                    }
-                    if (c.Overlaps(c)) {
-                        Assert.Fail();
-                    }
-                    if (c.Overlaps(d)) {
-                        Assert.Fail();
-                    }
-                    if (d.Overlaps(a)) {
-                        Assert.Fail();
-                    }
-                    if (d.Overlaps(b)) {
-                        Assert.Fail();
-                    }
-                    if (d.Overlaps(c)) {
-                        Assert.Fail();
-                    }
-                    if (d.Overlaps(d)) {
-                        Assert.Fail();
-                    }
-                    if (!a.Intersects(b)) {
-                        Assert.Fail();
-                    }
-                    if (!a.Intersects(d)) {
-                        Assert.Fail();
-                    }
-                    if (!b.Intersects(a)) {
-                        Assert.Fail();
-                    }
-                    if (!b.Intersects(c)) {
-                        Assert.Fail();
-                    }
-                    if (!c.Intersects(b)) {
-                        Assert.Fail();
-                    }
-                    if (!c.Intersects(d)) {
-                        Assert.Fail();
-                    }
-                    if (!d.Intersects(a)) {
-                        Assert.Fail();
-                    }
-                    if (!d.Intersects(c)) {
-                        Assert.Fail();
+                foreach (var segs in l) {
+                    for (var i = 1; i < segs.Length; i++) {
+                        AssertIntersects(segs[0], segs[i], true);
+                        AssertOverlaps(segs[0], segs[i], false);
                     }
                 }
             }
+
+            // Intersects, Overlaps
             {
-                var a = new Segment2I17F15(p1, p4);
-                var b = new Segment2I17F15(p2, p3);
-                var c = new Segment2I17F15(p4, p1);
-                var d = new Segment2I17F15(p3, p2);
-                if (a.Intersects(a)) {
-                    Assert.Fail();
-                }
-                if (a.Intersects(c)) {
-                    Assert.Fail();
-                }
-                if (b.Intersects(b)) {
-                    Assert.Fail();
-                }
-                if (b.Intersects(d)) {
-                    Assert.Fail();
-                }
-                if (c.Intersects(a)) {
-                    Assert.Fail();
-                }
-                if (c.Intersects(c)) {
-                    Assert.Fail();
-                }
-                if (d.Intersects(b)) {
-                    Assert.Fail();
-                }
-                if (d.Intersects(d)) {
-                    Assert.Fail();
-                }
-                if (a.Overlaps(a)) {
-                    Assert.Fail();
-                }
-                if (a.Overlaps(c)) {
-                    Assert.Fail();
-                }
-                if (b.Overlaps(b)) {
-                    Assert.Fail();
-                }
-                if (b.Overlaps(d)) {
-                    Assert.Fail();
-                }
-                if (c.Overlaps(a)) {
-                    Assert.Fail();
-                }
-                if (c.Overlaps(c)) {
-                    Assert.Fail();
-                }
-                if (d.Overlaps(b)) {
-                    Assert.Fail();
-                }
-                if (d.Overlaps(d)) {
-                    Assert.Fail();
-                }
-                if (!a.Intersects(b)) {
-                    Assert.Fail();
-                }
-                if (!a.Intersects(d)) {
-                    Assert.Fail();
-                }
-                if (!b.Intersects(a)) {
-                    Assert.Fail();
-                }
-                if (!b.Intersects(c)) {
-                    Assert.Fail();
-                }
-                if (!c.Intersects(b)) {
-                    Assert.Fail();
-                }
-                if (!c.Intersects(d)) {
-                    Assert.Fail();
-                }
-                if (!d.Intersects(a)) {
-                    Assert.Fail();
-                }
-                if (!d.Intersects(c)) {
-                    Assert.Fail();
-                }
-                if (!a.Overlaps(b)) {
-                    Assert.Fail();
-                }
-                if (!a.Overlaps(d)) {
-                    Assert.Fail();
-                }
-                if (!b.Overlaps(a)) {
-                    Assert.Fail();
-                }
-                if (!b.Overlaps(c)) {
-                    Assert.Fail();
-                }
-                if (!c.Overlaps(b)) {
-                    Assert.Fail();
-                }
-                if (!c.Overlaps(d)) {
-                    Assert.Fail();
-                }
-                if (!d.Overlaps(a)) {
-                    Assert.Fail();
-                }
-                if (!d.Overlaps(c)) {
-                    Assert.Fail();
-                }
+                var s1 = new Segment2I17F15(p1, p4);
+                var s2 = new Segment2I17F15(p2, p3);
+                AssertIntersects(s1, s2, true);
+                AssertOverlaps(s1, s2, true);
             }
         }
 

--- a/Intar/Geometry/Segment2I17F15.gen.cs
+++ b/Intar/Geometry/Segment2I17F15.gen.cs
@@ -256,21 +256,54 @@ namespace Intar.Geometry {
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Intersects(Segment2I17F15 other) {
-            var r = P2 - P1;
-            var s = other.P2 - other.P1;
-            var rxs = r.Determinant(s).Bits / I17F15.OneRepr;
-            if (rxs == 0) {
+            // 交点を求めない場合, より高精度の判定を行う.
+            // その場合, 事前にバウンディングボックスによる判定を
+            // 行う必要がある. (理由は後述)
+            if (!Envelope().Intersects(other.Envelope())) {
                 return false;
             }
 
-            var v = other.P1 - P1;
-            var t = v.Determinant(s).Bits / rxs;
-            if (t < 0 || I17F15.OneRepr < t) {
-                return false;
-            }
+            // 線分 AB, 線分 CD について交点が存在するとき,
+            // その交点を E とする.
+            // AB と CD がなす角を th,
+            // AC と AB がなす角を ph,
+            // AC と CD がなす角を lm とすると sin(th) < 0 の時
+            // 0 < |AC| sin(-ph) < |CD| sin(-th) かつ
+            // 0 < |AC| sin(-lm) < |AB| sin(-th) といえる.
+            // 上記の式を変形すると
+            // |CD| sin(th) < |AC| sin(ph) < 0
+            // |AB| sin(th) < |AC| sin(lm) < 0
+            // |AB| |CD| sin(th) < |AC| |AB| sin(ph) < 0
+            // |AB| |CD| sin(th) < |AC| |CD| sin(lm) < 0
 
-            var u = v.Determinant(r).Bits / rxs;
-            return 0 <= u && u <= I17F15.OneRepr;
+            var ab = P2 - P1;
+            var cd = other.P2 - other.P1;
+            var ac = other.P1 - P1;
+
+            // i の計算は最適化により早期リターンより後になることを期待している.
+
+            var g = ab.Determinant(cd); // |AB| |CD| sin(th)
+            var h = ac.Determinant(cd); // |AC| |CD| sin(lm)
+            var i = ac.Determinant(ab); // |AC| |AB| sin(ph)
+
+            // g = 0 の時, いずれか, または両方の線分の長さが
+            // 0 であるか, 線分が平行である. この時, h = 0 かつ
+            // i = 0 であればすべての端点が一点に重なるか,
+            // 一直線上に並ぶことを意味する. この時,
+            // バウンディングボックスによる事前判定によって 1 点に
+            // 重なるか, 線分が重なることが保証される.
+
+            if (g < I34F30.Zero) {
+                if (h < g || I34F30.Zero < h) {
+                    return false;
+                }
+                return g <= i && i <= I34F30.Zero;
+            } else {
+                if (h < I34F30.Zero || g < h) {
+                    return false;
+                }
+                return I34F30.Zero <= i && i <= g;
+            }
         }
 
         /// <summary>Check if the segment intersects with a circle.</summary>
@@ -397,21 +430,37 @@ namespace Intar.Geometry {
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Overlaps(Segment2I17F15 other) {
-            var r = P2 - P1;
-            var s = other.P2 - other.P1;
-            var rxs = r.Determinant(s).Bits / I17F15.OneRepr;
-            if (rxs == 0) {
-                return false;
-            }
+            var ab = P2 - P1;
+            var cd = other.P2 - other.P1;
+            var ac = other.P1 - P1;
 
-            var v = other.P1 - P1;
-            var t = v.Determinant(s).Bits / rxs;
-            if (t <= 0 || I17F15.OneRepr <= t) {
-                return false;
-            }
+            // i の計算は最適化により早期リターンより後になることを期待している.
 
-            var u = v.Determinant(r).Bits / rxs;
-            return 0 < u && u < I17F15.OneRepr;
+            var g = ab.Determinant(cd); // |AB| |CD| sin(th)
+            var h = ac.Determinant(cd); // |AC| |CD| sin(lm)
+            var i = ac.Determinant(ab); // |AC| |AB| sin(ph)
+
+            // Overlaps では g = 0 の場合, 後の分岐によって
+            // 必ず false が返る. g = 0 となる確率は低いため,
+            // ここでは早期リターンしない. Overlaps では
+            // g = 0 の場合常に false が返るため,
+            // すべての端点が一点に重なるか, 一直線上に並ぶ時に
+            // 誤って true を返すことはない. このため,
+            // バウンディングボックスによる事前判定を行わない.
+            // パフォーマンス最適化のためのバウンディングボックスによる
+            // 事前判定はユーザー責務となる.
+
+            if (g < I34F30.Zero) {
+                if (h <= g || I34F30.Zero <= h) {
+                    return false;
+                }
+                return g < i && i < I34F30.Zero;
+            } else {
+                if (h <= I34F30.Zero || g <= h) {
+                    return false;
+                }
+                return I34F30.Zero < i && i < g;
+            }
         }
 
         /// <summary>Check if the segment overlaps with a circle.


### PR DESCRIPTION
`Segment2I17F15` を引数とする `Segment2I17F15.Intersects` 及び同 `Overlaps` の交点を求めない場合のオーバーロードについての精度を改善した.