### PR TITLE
固定小数点数のシリアライズを改善

### DIFF
--- a/.generator/templates/FixedDrawer.cs
+++ b/.generator/templates/FixedDrawer.cs
@@ -28,22 +28,13 @@ namespace {{ namespace }}.Editor {
         }
 
         internal static float Restore({{ bits_type }} bits) {
-            float f;
-            {
-                {%- if signed %}
-                var sign = 0.5f * System.Math.Sign(bits);
-                {%- else %}
-                var sign = bits == 0 ? 0.0f : 0.5f;
-                {%- endif %}
-                f = bits * 100.0f / {{ type }}.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / {{ type }}.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            {{ bits_type }} i;
-            {
-                var tmp = f * {{ type }}.OneRepr;
-                i = ({{ bits_type }})tmp;
-            }
-            return bits == i ? f : (float)bits / {{ type }}.OneRepr;
+            return (float)bits / {{ type }}.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/I17F15Drawer.gen.cs
+++ b/Intar.Editor/I17F15Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(int bits) {
-            float f;
-            {
-                var sign = 0.5f * System.Math.Sign(bits);
-                f = bits * 100.0f / I17F15.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / I17F15.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            int i;
-            {
-                var tmp = f * I17F15.OneRepr;
-                i = (int)tmp;
-            }
-            return bits == i ? f : (float)bits / I17F15.OneRepr;
+            return (float)bits / I17F15.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/I2F30Drawer.gen.cs
+++ b/Intar.Editor/I2F30Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(int bits) {
-            float f;
-            {
-                var sign = 0.5f * System.Math.Sign(bits);
-                f = bits * 100.0f / I2F30.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / I2F30.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            int i;
-            {
-                var tmp = f * I2F30.OneRepr;
-                i = (int)tmp;
-            }
-            return bits == i ? f : (float)bits / I2F30.OneRepr;
+            return (float)bits / I2F30.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/I2F62Drawer.gen.cs
+++ b/Intar.Editor/I2F62Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(long bits) {
-            float f;
-            {
-                var sign = 0.5f * System.Math.Sign(bits);
-                f = bits * 100.0f / I2F62.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / I2F62.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            long i;
-            {
-                var tmp = f * I2F62.OneRepr;
-                i = (long)tmp;
-            }
-            return bits == i ? f : (float)bits / I2F62.OneRepr;
+            return (float)bits / I2F62.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/I33F31Drawer.gen.cs
+++ b/Intar.Editor/I33F31Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(long bits) {
-            float f;
-            {
-                var sign = 0.5f * System.Math.Sign(bits);
-                f = bits * 100.0f / I33F31.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / I33F31.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            long i;
-            {
-                var tmp = f * I33F31.OneRepr;
-                i = (long)tmp;
-            }
-            return bits == i ? f : (float)bits / I33F31.OneRepr;
+            return (float)bits / I33F31.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/I34F30Drawer.gen.cs
+++ b/Intar.Editor/I34F30Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(long bits) {
-            float f;
-            {
-                var sign = 0.5f * System.Math.Sign(bits);
-                f = bits * 100.0f / I34F30.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / I34F30.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            long i;
-            {
-                var tmp = f * I34F30.OneRepr;
-                i = (long)tmp;
-            }
-            return bits == i ? f : (float)bits / I34F30.OneRepr;
+            return (float)bits / I34F30.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/I4F60Drawer.gen.cs
+++ b/Intar.Editor/I4F60Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(long bits) {
-            float f;
-            {
-                var sign = 0.5f * System.Math.Sign(bits);
-                f = bits * 100.0f / I4F60.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / I4F60.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            long i;
-            {
-                var tmp = f * I4F60.OneRepr;
-                i = (long)tmp;
-            }
-            return bits == i ? f : (float)bits / I4F60.OneRepr;
+            return (float)bits / I4F60.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/U17F15Drawer.gen.cs
+++ b/Intar.Editor/U17F15Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(uint bits) {
-            float f;
-            {
-                var sign = bits == 0 ? 0.0f : 0.5f;
-                f = bits * 100.0f / U17F15.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / U17F15.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            uint i;
-            {
-                var tmp = f * U17F15.OneRepr;
-                i = (uint)tmp;
-            }
-            return bits == i ? f : (float)bits / U17F15.OneRepr;
+            return (float)bits / U17F15.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/U2F30Drawer.gen.cs
+++ b/Intar.Editor/U2F30Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(uint bits) {
-            float f;
-            {
-                var sign = bits == 0 ? 0.0f : 0.5f;
-                f = bits * 100.0f / U2F30.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / U2F30.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            uint i;
-            {
-                var tmp = f * U2F30.OneRepr;
-                i = (uint)tmp;
-            }
-            return bits == i ? f : (float)bits / U2F30.OneRepr;
+            return (float)bits / U2F30.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/U2F62Drawer.gen.cs
+++ b/Intar.Editor/U2F62Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(ulong bits) {
-            float f;
-            {
-                var sign = bits == 0 ? 0.0f : 0.5f;
-                f = bits * 100.0f / U2F62.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / U2F62.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            ulong i;
-            {
-                var tmp = f * U2F62.OneRepr;
-                i = (ulong)tmp;
-            }
-            return bits == i ? f : (float)bits / U2F62.OneRepr;
+            return (float)bits / U2F62.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/U33F31Drawer.gen.cs
+++ b/Intar.Editor/U33F31Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(ulong bits) {
-            float f;
-            {
-                var sign = bits == 0 ? 0.0f : 0.5f;
-                f = bits * 100.0f / U33F31.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / U33F31.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            ulong i;
-            {
-                var tmp = f * U33F31.OneRepr;
-                i = (ulong)tmp;
-            }
-            return bits == i ? f : (float)bits / U33F31.OneRepr;
+            return (float)bits / U33F31.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/U34F30Drawer.gen.cs
+++ b/Intar.Editor/U34F30Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(ulong bits) {
-            float f;
-            {
-                var sign = bits == 0 ? 0.0f : 0.5f;
-                f = bits * 100.0f / U34F30.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / U34F30.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            ulong i;
-            {
-                var tmp = f * U34F30.OneRepr;
-                i = (ulong)tmp;
-            }
-            return bits == i ? f : (float)bits / U34F30.OneRepr;
+            return (float)bits / U34F30.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that

--- a/Intar.Editor/U4F60Drawer.gen.cs
+++ b/Intar.Editor/U4F60Drawer.gen.cs
@@ -24,18 +24,13 @@ namespace Intar.Editor {
         }
 
         internal static float Restore(ulong bits) {
-            float f;
-            {
-                var sign = bits == 0 ? 0.0f : 0.5f;
-                f = bits * 100.0f / U4F60.OneRepr;
-                f = Mathf.Round(f + sign) / 100;
+            for (var scale = 1.0f; scale < (1 << 25); scale *= 10) {
+                var f = Mathf.Round(bits * scale / U4F60.OneRepr) / scale;
+                if (bits == ToBits(f)) {
+                    return f;
+                }
             }
-            ulong i;
-            {
-                var tmp = f * U4F60.OneRepr;
-                i = (ulong)tmp;
-            }
-            return bits == i ? f : (float)bits / U4F60.OneRepr;
+            return (float)bits / U4F60.OneRepr;
         }
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
             // Using BeginProperty / EndProperty on the parent property means that


### PR DESCRIPTION
不要な桁をできるだけ表示しないようにする仕組みを改善した。

何故か 0.5 を足してから丸めたりしていた箇所を修正し、ToBits と for 文を使ったシンプルな仕組みに変更した。