### PR TITLE
固定小数点型 非静的メンバメソッドの Atan2 を削除

### DIFF
--- a/.generator/templates/Fixed.cs
+++ b/.generator/templates/Fixed.cs
@@ -321,7 +321,7 @@ namespace {{ namespace }} {
         {%- endfor %}
         #endregion
         {%- endif %}
-        {%- if bits < 128 %}
+        {%- if bits < 128 and int_nbits == 2 %}
         #region Atan2
         {%- if bits == 64 %}
 
@@ -333,18 +333,10 @@ namespace {{ namespace }} {
 
         {%- for order in [2, 3, 9] %}
         {%- if order > 3 and bits < 64 %}{% continue %}{% endif %}
-        {%- set atan = macros::fixed_type(i=2, f=bits-2, s=true) %}
-        {%- if int_nbits == 2 %}
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static {{ self_type }} Atan2P{{ order }}({{ self_bits_type }} y, {{ self_bits_type }} x) {
             return {{ self_type }}.FromBits(Mathi.Atan2P{{ order }}(y, x));
-        }
-        {%- endif %}
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public {{ atan }} Atan2P{{ order }}({{ self_type }} other) {
-            return {{ atan }}.Atan2P{{ order }}(Bits, other.Bits);
         }
         {%- endfor %}
 

--- a/Intar/I17F15.gen.cs
+++ b/Intar/I17F15.gen.cs
@@ -204,25 +204,6 @@ namespace Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public I2F30 AtanP3() => AtanP3(Bits);
         #endregion
-        #region Atan2
-
-#pragma warning disable IDE0079 // 不要な抑制を削除します
-#pragma warning disable IDE0002 // メンバー アクセスを単純化します
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F30 Atan2P2(I17F15 other) {
-            return I2F30.Atan2P2(Bits, other.Bits);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F30 Atan2P3(I17F15 other) {
-            return I2F30.Atan2P3(Bits, other.Bits);
-        }
-
-#pragma warning restore IDE0002 // メンバー アクセスを単純化します
-#pragma warning restore IDE0079 // 不要な抑制を削除します
-
-        #endregion
         #region Sin, Cos
 
         /// <summary>

--- a/Intar/I2F30.gen.cs
+++ b/Intar/I2F30.gen.cs
@@ -189,18 +189,8 @@ namespace Intar {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F30 Atan2P2(I2F30 other) {
-            return I2F30.Atan2P2(Bits, other.Bits);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static I2F30 Atan2P3(int y, int x) {
             return I2F30.FromBits(Mathi.Atan2P3(y, x));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F30 Atan2P3(I2F30 other) {
-            return I2F30.Atan2P3(Bits, other.Bits);
         }
 
 #pragma warning restore IDE0002 // メンバー アクセスを単純化します

--- a/Intar/I2F62.gen.cs
+++ b/Intar/I2F62.gen.cs
@@ -196,28 +196,13 @@ namespace Intar {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P2(I2F62 other) {
-            return I2F62.Atan2P2(Bits, other.Bits);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static I2F62 Atan2P3(long y, long x) {
             return I2F62.FromBits(Mathi.Atan2P3(y, x));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P3(I2F62 other) {
-            return I2F62.Atan2P3(Bits, other.Bits);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static I2F62 Atan2P9(long y, long x) {
             return I2F62.FromBits(Mathi.Atan2P9(y, x));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P9(I2F62 other) {
-            return I2F62.Atan2P9(Bits, other.Bits);
         }
 
 #pragma warning restore IDE0002 // メンバー アクセスを単純化します

--- a/Intar/I33F31.gen.cs
+++ b/Intar/I33F31.gen.cs
@@ -227,34 +227,6 @@ namespace Intar {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public I2F62 AtanP9() => AtanP9(Bits);
         #endregion
-        #region Atan2
-
-#if NET7_0_OR_GREATER
-
-#pragma warning disable IDE0079 // 不要な抑制を削除します
-#pragma warning disable IDE0002 // メンバー アクセスを単純化します
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P2(I33F31 other) {
-            return I2F62.Atan2P2(Bits, other.Bits);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P3(I33F31 other) {
-            return I2F62.Atan2P3(Bits, other.Bits);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P9(I33F31 other) {
-            return I2F62.Atan2P9(Bits, other.Bits);
-        }
-
-#pragma warning restore IDE0002 // メンバー アクセスを単純化します
-#pragma warning restore IDE0079 // 不要な抑制を削除します
-
-#endif // NET7_0_OR_GREATER
-
-        #endregion
         #region Sin, Cos
 
         /// <summary>

--- a/Intar/I34F30.gen.cs
+++ b/Intar/I34F30.gen.cs
@@ -198,34 +198,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Atan2
-
-#if NET7_0_OR_GREATER
-
-#pragma warning disable IDE0079 // 不要な抑制を削除します
-#pragma warning disable IDE0002 // メンバー アクセスを単純化します
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P2(I34F30 other) {
-            return I2F62.Atan2P2(Bits, other.Bits);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P3(I34F30 other) {
-            return I2F62.Atan2P3(Bits, other.Bits);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P9(I34F30 other) {
-            return I2F62.Atan2P9(Bits, other.Bits);
-        }
-
-#pragma warning restore IDE0002 // メンバー アクセスを単純化します
-#pragma warning restore IDE0079 // 不要な抑制を削除します
-
-#endif // NET7_0_OR_GREATER
-
-        #endregion
         #region Swizzling
         public Vector2I34F30 X0() => Vector2I34F30.FromRepr(new Vector2Int64(Bits, 0));
         public Vector2I34F30 X1() => Vector2I34F30.FromRepr(new Vector2Int64(Bits, OneRepr));

--- a/Intar/I4F60.gen.cs
+++ b/Intar/I4F60.gen.cs
@@ -198,34 +198,6 @@ namespace Intar {
 #endif // NET7_0_OR_GREATER
 
         #endregion
-        #region Atan2
-
-#if NET7_0_OR_GREATER
-
-#pragma warning disable IDE0079 // 不要な抑制を削除します
-#pragma warning disable IDE0002 // メンバー アクセスを単純化します
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P2(I4F60 other) {
-            return I2F62.Atan2P2(Bits, other.Bits);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P3(I4F60 other) {
-            return I2F62.Atan2P3(Bits, other.Bits);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public I2F62 Atan2P9(I4F60 other) {
-            return I2F62.Atan2P9(Bits, other.Bits);
-        }
-
-#pragma warning restore IDE0002 // メンバー アクセスを単純化します
-#pragma warning restore IDE0079 // 不要な抑制を削除します
-
-#endif // NET7_0_OR_GREATER
-
-        #endregion
         #region Swizzling
         public Vector2I4F60 X0() => Vector2I4F60.FromRepr(new Vector2Int64(Bits, 0));
         public Vector2I4F60 X1() => Vector2I4F60.FromRepr(new Vector2Int64(Bits, OneRepr));


### PR DESCRIPTION
非静的メソッドの `I2F30.Atan2P2` ､ `I2F30.Atan2P3` ､
`I17F15.Atan2P2` ､ `I17F15.Atan2P3` ､
`I2F62.Atan2P2` ､ `I2F62.Atan2P3` ､ `I2F62.Atan2P9` ､
`I4F60.Atan2P2` ､ `I4F60.Atan2P3` ､ `I4F60.Atan2P9` ､
`I33F31.Atan2P2` ､ `I33F31.Atan2P3` ､ `I33F31.Atan2P9` ､
`I34F30.Atan2P2` ､ `I34F30.Atan2P3` ､ `I34F30.Atan2P9` を削除した｡