### PR TITLE
クォータニオンの球面補間時に､ 正確に鏡面対称な Acos を使用するように修正

### DIFF
--- a/.generator/templates/Quaternion.cs
+++ b/.generator/templates/Quaternion.cs
@@ -294,13 +294,11 @@ namespace {{ namespace }} {
                 );
 
                 // ドット積の Arccos を計算する.
-                // その後, 後の計算のために小数部の精度を {{ (int_nbits+frac_nbits-2)/2 }} ビットにする.
+                // 後の計算のために小数部の精度を {{ (int_nbits+frac_nbits-2)/2 }} ビットにする.
                 {#- 32 ビットのクォータニオンには AcosP3(long) を,
                     64 ビットのクォータニオンには AcosP7(Int128) を使用する. #}
-                var angle = ({{
+                var angle = {{
                     macros::fixed_type(s=true, i=(int_nbits+frac_nbits)/2 + 1, f=(int_nbits+frac_nbits)/2 - 1)
-                }}){{
-                    macros::fixed_type(s=false, i=2, f=2*int_nbits+2*frac_nbits-2)
                 }}.AcosP{%
                     if   int_nbits + frac_nbits == 32 %}3{%
                     elif int_nbits + frac_nbits == 64 %}7{%

--- a/Intar/QuaternionI2F30.gen.cs
+++ b/Intar/QuaternionI2F30.gen.cs
@@ -268,8 +268,8 @@ namespace Intar {
                 var d = U33F31.FromBits((ulong)dot.Bits >> 29);
 
                 // ドット積の Arccos を計算する.
-                // その後, 後の計算のために小数部の精度を 15 ビットにする.
-                var angle = (I17F15)U2F62.AcosP3((I33F31)d);
+                // 後の計算のために小数部の精度を 15 ビットにする.
+                var angle = I17F15.AcosP3((I33F31)d);
 
                 // 閾値が 0.0005 の場合 invSin の最大値は
                 // (1 - (1-0.0005)^2)^(-0.5)=31.6267301900746 となる.


### PR DESCRIPTION
<!-- I want to review in Japanese. -->